### PR TITLE
feat(lsp): declare UTF-8 position encoding

### DIFF
--- a/crates/ase-ls/src/server.rs
+++ b/crates/ase-ls/src/server.rs
@@ -73,6 +73,7 @@ impl LanguageServer for AseLanguageServer {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
+                position_encoding: Some(PositionEncodingKind::UTF8),
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(
                     TextDocumentSyncKind::FULL,
                 )),


### PR DESCRIPTION
## Summary
- Add `position_encoding: Some(PositionEncodingKind::UTF8)` to ServerCapabilities
- ASE T-SQL is predominantly ASCII, so UTF-8 position encoding is safe and avoids the complexity of UTF-16 offset calculation

## Test plan
- [x] cargo check -p ase-ls passes
- [x] cargo test --all passes (870+ tests)
- [x] cargo clippy --all-targets -- -D warnings passes

## Technical details
- Verified that `PositionEncodingKind::UTF8` is available in lsp-types 0.94
- The field is added at the top of ServerCapabilities initialization
- No changes needed to position calculation logic (already uses byte offsets which match UTF-8 for ASCII)

🤖 Generated with [Claude Code](https://claude.com/claude-code)