### PR TITLE
refactor(lsp): Phase 5 minor debt cleanup

### DIFF
--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -22,7 +22,7 @@ pub fn code_actions(source: &str, range: Range, uri: &lsp_types::Url) -> Vec<Cod
     }
 
     // シンボルテーブルを構築（現在行より前の部分も試行）
-    let symbol_table = build_resilient_symbol_table(source);
+    let symbol_table = build_fallback_symbol_table(source);
 
     // SELECT * FROM table → カラム展開
     if let Some(action) = try_expand_select_star(&symbol_table, &line_text, range.start, uri) {
@@ -43,11 +43,11 @@ pub fn code_actions(source: &str, range: Range, uri: &lsp_types::Url) -> Vec<Cod
     actions
 }
 
-/// レジリエントなシンボルテーブル構築
+/// フォールバック付きシンボルテーブル構築
 ///
 /// 完全なパースに失敗した場合、ソースを行ごとに分割して
 /// 前方部分だけをパースし、DDL定義を抽出する。
-fn build_resilient_symbol_table(source: &str) -> crate::symbol_table::SymbolTable {
+fn build_fallback_symbol_table(source: &str) -> crate::symbol_table::SymbolTable {
     let table = SymbolTableBuilder::build_tolerant(source);
     if !table.tables.is_empty() {
         return table;

--- a/crates/ase-ls-core/src/formatting.rs
+++ b/crates/ase-ls-core/src/formatting.rs
@@ -159,7 +159,9 @@ fn should_newline_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bool {
         | TokenKind::End
         | TokenKind::Try
         | TokenKind::Catch => {
-            // SELECTの直後でFROMが来る場合は改行しない（単純SELECT用）
+            // Rationale: SELECTとFROMは同一行に保つ。これにより "SELECT col FROM t" が
+            // 1行にフォーマットされ、短いクエリの可読性が向上する。FROMのみを改行
+            // 対象キーワードに含めつつ、SELECT直後のFROMだけを例外的に同一行扱いにする。
             if matches!(prev, TokenKind::Select) && matches!(kind, TokenKind::From) {
                 return false;
             }


### PR DESCRIPTION
## Summary
- Add rationale comment to formatting.rs explaining SELECT...FROM same-line handling
- Rename `build_resilient_symbol_table` → `build_fallback_symbol_table` in code_actions.rs for accurate naming

## Test plan
- [x] `cargo test --all` — 864 tests passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)