### PR TITLE
feat(lsp): add DocumentAnalysis cache layer

### DIFF
--- a/crates/ase-ls-core/src/analysis.rs
+++ b/crates/ase-ls-core/src/analysis.rs
@@ -1,0 +1,208 @@
+//! Document Analysis — pre-computed derived data for a source document.
+//!
+//! Constructs all derived data (LineIndex, tokens, AST, symbol table) once
+//! per source change, so LSP handlers can share the results without re-parsing.
+
+use crate::line_index::LineIndex;
+use crate::symbol_table::{SymbolTable, SymbolTableBuilder};
+use tsql_token::{Span, TokenKind};
+
+/// Owned copy of a lexer token, without lifetime dependency on source.
+#[derive(Debug, Clone)]
+pub struct OwnedToken {
+    /// Token kind (keyword, identifier, operator, etc.)
+    pub kind: TokenKind,
+    /// Token text (cloned from source).
+    pub text: String,
+    /// Byte span in source.
+    pub span: Span,
+}
+
+impl Clone for DocumentAnalysis {
+    fn clone(&self) -> Self {
+        Self {
+            source: self.source.clone(),
+            line_index: LineIndex::new(&self.source),
+            tokens: self.tokens.clone(),
+            statements: self.statements.clone(),
+            parse_errors: self.parse_errors.clone(),
+            symbol_table: self.symbol_table.clone(),
+        }
+    }
+}
+
+/// Pre-computed analysis of a source document.
+///
+/// Built once per `did_open`/`did_change`, shared by all LSP handlers.
+pub struct DocumentAnalysis {
+    /// Original source text (needed for position_to_offset and formatting).
+    pub source: String,
+    /// Pre-computed line offset index for O(log n) position conversion.
+    pub line_index: LineIndex,
+    /// All tokens from lexer (owned copies).
+    pub tokens: Vec<OwnedToken>,
+    /// Parsed AST statements.
+    pub statements: Vec<tsql_parser::ast::Statement>,
+    /// Parse errors (if any).
+    pub parse_errors: Vec<tsql_parser::ParseError>,
+    /// Extracted symbol table.
+    pub symbol_table: SymbolTable,
+}
+
+impl DocumentAnalysis {
+    /// Build a full analysis from source text.
+    pub fn new(source: &str) -> Self {
+        let owned_source = source.to_string();
+        let line_index = LineIndex::new(source);
+
+        let tokens: Vec<OwnedToken> = tsql_lexer::Lexer::new(source)
+            .filter_map(|r| r.ok())
+            .map(|t| OwnedToken {
+                kind: t.kind,
+                text: t.text.to_string(),
+                span: t.span,
+            })
+            .collect();
+
+        let tokens_with_comments: Vec<OwnedToken> = tsql_lexer::Lexer::new(source)
+            .with_comments(true)
+            .filter_map(|r| r.ok())
+            .map(|t| OwnedToken {
+                kind: t.kind,
+                text: t.text.to_string(),
+                span: t.span,
+            })
+            .collect();
+
+        let (statements, parse_errors) = match tsql_parser::Parser::new(source).parse_with_errors()
+        {
+            Ok((stmts, errs)) => (stmts, errs),
+            Err(errs) => (Vec::new(), errs.errors),
+        };
+
+        let symbol_table = SymbolTableBuilder::build_tolerant(source);
+
+        let _ = tokens_with_comments;
+        Self {
+            source: owned_source,
+            line_index,
+            tokens,
+            statements,
+            parse_errors,
+            symbol_table,
+        }
+    }
+
+    /// Find the token at a given byte offset using binary search. O(log n).
+    pub fn find_token_at(&self, offset: usize) -> Option<(&OwnedToken, usize)> {
+        let idx = self
+            .tokens
+            .partition_point(|t| t.span.start as usize <= offset);
+        if idx == 0 {
+            return None;
+        }
+        let token = &self.tokens[idx - 1];
+        let end = token.span.end as usize;
+        if offset < end {
+            Some((token, idx - 1))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_analysis_builds_line_index() {
+        let analysis = DocumentAnalysis::new("SELECT *\nFROM users");
+        assert_eq!(analysis.line_index.offset_to_position(0), (0, 0));
+        assert_eq!(analysis.line_index.offset_to_position(9), (1, 0)); // after \n
+    }
+
+    #[test]
+    fn test_analysis_collects_tokens() {
+        let analysis = DocumentAnalysis::new("SELECT * FROM users");
+        assert!(!analysis.tokens.is_empty());
+        // First token should be SELECT
+        assert_eq!(analysis.tokens[0].kind, TokenKind::Select);
+        assert_eq!(analysis.tokens[0].text, "SELECT");
+    }
+
+    #[test]
+    fn test_analysis_parses_statements() {
+        let analysis = DocumentAnalysis::new("SELECT * FROM users");
+        assert_eq!(analysis.statements.len(), 1);
+    }
+
+    #[test]
+    fn test_analysis_collects_parse_errors() {
+        let analysis = DocumentAnalysis::new("SELCT * FROM");
+        assert!(!analysis.parse_errors.is_empty());
+    }
+
+    #[test]
+    fn test_analysis_builds_symbol_table() {
+        let source = "CREATE TABLE users (id INT)";
+        let analysis = DocumentAnalysis::new(source);
+        assert!(analysis.symbol_table.tables.contains_key("USERS"));
+    }
+
+    #[test]
+    fn test_analysis_empty_source() {
+        let analysis = DocumentAnalysis::new("");
+        assert!(analysis.tokens.is_empty());
+        assert!(analysis.statements.is_empty());
+        assert!(analysis.parse_errors.is_empty());
+        assert!(analysis.symbol_table.tables.is_empty());
+    }
+
+    #[test]
+    fn test_analysis_invalid_sql_partial_results() {
+        // Invalid SQL should still produce tokens and capture errors
+        let analysis = DocumentAnalysis::new("SELCT FRO users");
+        assert!(!analysis.tokens.is_empty());
+        assert!(!analysis.parse_errors.is_empty());
+    }
+
+    #[test]
+    fn test_find_token_at_start() {
+        let analysis = DocumentAnalysis::new("SELECT * FROM users");
+        let (token, _) = analysis.find_token_at(0).unwrap();
+        assert_eq!(token.kind, TokenKind::Select);
+        assert_eq!(token.text, "SELECT");
+    }
+
+    #[test]
+    fn test_find_token_at_mid() {
+        let analysis = DocumentAnalysis::new("SELECT * FROM users");
+        let (token, _) = analysis.find_token_at(3).unwrap();
+        assert_eq!(token.text, "SELECT");
+    }
+
+    #[test]
+    fn test_find_token_at_whitespace() {
+        let analysis = DocumentAnalysis::new("SELECT * FROM users");
+        // offset 6 is space after SELECT
+        assert!(analysis.find_token_at(6).is_none());
+    }
+
+    #[test]
+    fn test_find_token_at_past_end() {
+        let analysis = DocumentAnalysis::new("SELECT");
+        assert!(analysis.find_token_at(100).is_none());
+    }
+
+    #[test]
+    fn test_find_token_at_variable() {
+        let analysis = DocumentAnalysis::new("DECLARE @count INT");
+        let (token, _) = analysis.find_token_at(8).unwrap();
+        assert_eq!(token.kind, TokenKind::LocalVar);
+        assert_eq!(token.text, "@count");
+    }
+}

--- a/crates/ase-ls-core/src/definition.rs
+++ b/crates/ase-ls-core/src/definition.rs
@@ -8,6 +8,7 @@
 //! - ビュー参照 → CREATE VIEW定義
 //! - インデックス参照 → CREATE INDEX定義
 
+use crate::analysis::DocumentAnalysis;
 use crate::line_index::LineIndex;
 use crate::symbol_table::{SymbolTable, SymbolTableBuilder};
 
@@ -15,9 +16,30 @@ use crate::find_token_at;
 use lsp_types::{Position, Range};
 use tsql_token::TokenKind;
 
-/// カーソル位置のシンボルの定義箇所を検索する
-///
-/// 戻り値は定義箇所のRangeのリスト。空の場合は定義なし。
+/// カーソル位置のシンボルの定義箇所を検索する（DocumentAnalysis利用）
+pub fn definition_ranges_with_analysis(
+    analysis: &DocumentAnalysis,
+    position: Position,
+) -> Vec<Range> {
+    let offset = analysis
+        .line_index
+        .position_to_offset(&analysis.source, position);
+
+    let (target_kind, target_text) = match analysis.find_token_at(offset) {
+        Some((t, _)) => (t.kind, t.text.clone()),
+        None => return Vec::new(),
+    };
+
+    let search_name = target_text.to_uppercase();
+
+    if target_kind == TokenKind::LocalVar {
+        find_variable_definition(&analysis.symbol_table, &search_name)
+    } else {
+        find_object_definition(&analysis.symbol_table, &search_name)
+    }
+}
+
+/// カーソル位置のシンボルの定義箇所を検索する（ソースから構築）
 pub fn definition_ranges(source: &str, position: Position) -> Vec<Range> {
     let line_index = LineIndex::new(source);
     let offset = line_index.position_to_offset(source, position);

--- a/crates/ase-ls-core/src/diagnostics.rs
+++ b/crates/ase-ls-core/src/diagnostics.rs
@@ -2,9 +2,19 @@
 //!
 //! パーサーのエラーを LSP Diagnostic に変換する。
 
+use crate::analysis::DocumentAnalysis;
 use crate::line_index::LineIndex;
 use lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 use tsql_parser::ParseError;
+
+/// DocumentAnalysisから診断を生成する（キャッシュ利用）
+pub fn diagnose(analysis: &DocumentAnalysis) -> Vec<Diagnostic> {
+    analysis
+        .parse_errors
+        .iter()
+        .map(|e| parse_error_to_diagnostic(&analysis.line_index, e))
+        .collect()
+}
 
 /// ParseError を LSP Diagnostic に変換する
 pub fn parse_errors_to_diagnostics(source: &str, errors: &[ParseError]) -> Vec<Diagnostic> {
@@ -141,5 +151,25 @@ mod tests {
         let source = "CREATE TABLE t (id INT)\nINSERT INTO t (id) VALUES (1)\nSELECT * FROM t";
         let diags = diagnose_source(source);
         assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn test_diagnose_matches_diagnose_source() {
+        let sources = [
+            "SELECT * FROM users",
+            "SELCT * FROM",
+            "CREATE TABLE t (id INT)",
+            "",
+        ];
+        for source in &sources {
+            let analysis = crate::analysis::DocumentAnalysis::new(source);
+            let from_analysis = diagnose(&analysis);
+            let from_source = diagnose_source(source);
+            assert_eq!(
+                from_analysis.len(),
+                from_source.len(),
+                "Mismatch for source: {source:?}"
+            );
+        }
     }
 }

--- a/crates/ase-ls-core/src/hover.rs
+++ b/crates/ase-ls-core/src/hover.rs
@@ -3,12 +3,49 @@
 //! T-SQL キーワード、データ型、組み込み関数、変数のホバー情報を提供する。
 //! 静的ドキュメントデータは [`crate::db_docs`] モジュールに集約されている。
 
+use crate::analysis::DocumentAnalysis;
 use crate::line_index::LineIndex;
 use lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position, Range};
 use tsql_lexer::Lexer;
 use tsql_token::TokenKind;
 
-/// Hover情報を生成する
+/// Hover情報を生成する（DocumentAnalysis利用）
+pub fn hover_with_analysis(analysis: &DocumentAnalysis, position: Position) -> Option<Hover> {
+    let offset = analysis
+        .line_index
+        .position_to_offset(&analysis.source, position);
+
+    let (token, _idx) = analysis.find_token_at(offset)?;
+    let kind = token.kind;
+    let text = token.text.clone();
+    let start = token.span.start as usize;
+    let end = token.span.end as usize;
+
+    let content = build_schema_hover(&analysis.symbol_table, &kind, &text)
+        .or_else(|| build_hover_content(&kind, &text))?;
+
+    let (start_line, start_char) = analysis.line_index.offset_to_position(start as u32);
+    let (end_line, end_char) = analysis.line_index.offset_to_position(end as u32);
+
+    Some(Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: content,
+        }),
+        range: Some(Range {
+            start: Position {
+                line: start_line,
+                character: start_char,
+            },
+            end: Position {
+                line: end_line,
+                character: end_char,
+            },
+        }),
+    })
+}
+
+/// Hover情報を生成する（ソースから構築）
 ///
 /// カーソル位置のトークンを特定し、対応するドキュメントを返す。
 /// まずシンボルテーブルを検索し、見つからなければ静的ドキュメントにフォールバックする。

--- a/crates/ase-ls-core/src/lib.rs
+++ b/crates/ase-ls-core/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(clippy::expect_used)]
 #![warn(clippy::panic)]
 
+pub mod analysis;
 pub mod code_actions;
 pub mod completion;
 pub mod db_docs;

--- a/crates/ase-ls-core/src/line_index.rs
+++ b/crates/ase-ls-core/src/line_index.rs
@@ -6,7 +6,7 @@ use lsp_types::Position;
 ///
 /// Builds a table of byte offsets for each line start, enabling
 /// binary search instead of linear scan for offset→position and position→offset.
-pub(crate) struct LineIndex {
+pub struct LineIndex {
     /// Byte offset of each line start. line_offsets[i] = byte offset of line i.
     /// Always has at least one entry (offset 0 for line 0).
     line_offsets: Vec<u32>,
@@ -14,7 +14,7 @@ pub(crate) struct LineIndex {
 
 impl LineIndex {
     /// Build the line index from source text. O(n) construction.
-    pub(crate) fn new(source: &str) -> Self {
+    pub fn new(source: &str) -> Self {
         let mut offsets = vec![0u32];
         for (i, b) in source.bytes().enumerate() {
             if b == b'\n' {
@@ -27,7 +27,7 @@ impl LineIndex {
     }
 
     /// Convert a byte offset to (line, character), both 0-indexed. O(log n).
-    pub(crate) fn offset_to_position(&self, offset: u32) -> (u32, u32) {
+    pub fn offset_to_position(&self, offset: u32) -> (u32, u32) {
         let line = self.line_number(offset);
         let line_start = self.line_offsets[line as usize];
         let character = offset.saturating_sub(line_start);
@@ -35,7 +35,7 @@ impl LineIndex {
     }
 
     /// Convert an LSP Position to a byte offset. O(log n) + O(line_length).
-    pub(crate) fn position_to_offset(&self, source: &str, position: Position) -> usize {
+    pub fn position_to_offset(&self, source: &str, position: Position) -> usize {
         let line = position.line as usize;
         if line >= self.line_offsets.len() {
             return source.len();

--- a/crates/ase-ls-core/src/signature_help.rs
+++ b/crates/ase-ls-core/src/signature_help.rs
@@ -2,12 +2,106 @@
 //!
 //! 組み込み関数のパラメータシグネチャを提供する。
 
+use crate::analysis::DocumentAnalysis;
 use crate::line_index::LineIndex;
 use lsp_types::{
     ParameterInformation, ParameterLabel, Position, SignatureHelp, SignatureInformation,
 };
 use tsql_lexer::Lexer;
 use tsql_token::TokenKind;
+
+/// SignatureHelp情報を生成する（DocumentAnalysis利用）
+pub fn signature_help_with_analysis(
+    analysis: &DocumentAnalysis,
+    position: Position,
+) -> Option<SignatureHelp> {
+    let offset = analysis
+        .line_index
+        .position_to_offset(&analysis.source, position);
+
+    let mut func_name: Option<String> = None;
+    let mut paren_depth = 0i32;
+    let mut active_param = 0u32;
+    let mut found_open_paren = false;
+
+    for token in &analysis.tokens {
+        if token.span.start as usize > offset {
+            break;
+        }
+
+        match token.kind {
+            TokenKind::Ident => {
+                if !found_open_paren {
+                    func_name = Some(token.text.to_uppercase());
+                }
+            }
+            TokenKind::LParen => {
+                if !found_open_paren {
+                    found_open_paren = true;
+                    paren_depth = 1;
+                } else {
+                    paren_depth += 1;
+                }
+            }
+            TokenKind::RParen => {
+                paren_depth -= 1;
+                if paren_depth == 0 {
+                    found_open_paren = false;
+                    func_name = None;
+                    active_param = 0;
+                }
+            }
+            TokenKind::Comma => {
+                if paren_depth == 1 {
+                    active_param += 1;
+                }
+            }
+            _ => {
+                if !found_open_paren && token.kind.is_keyword() {
+                    func_name = Some(token.text.to_uppercase());
+                }
+            }
+        }
+    }
+
+    if !found_open_paren {
+        return None;
+    }
+    let name = func_name?;
+    let entry = crate::db_docs::lookup_function(name.as_str())?;
+
+    if entry.category != crate::db_docs::DocCategory::Function {
+        return None;
+    }
+
+    let parameters: Vec<ParameterInformation> = entry
+        .params
+        .iter()
+        .map(|p| ParameterInformation {
+            label: ParameterLabel::Simple(p.to_string()),
+            documentation: None,
+        })
+        .collect();
+
+    let active_parameter = if active_param < parameters.len() as u32 {
+        Some(active_param)
+    } else {
+        Some((parameters.len() as u32).saturating_sub(1))
+    };
+
+    Some(SignatureHelp {
+        signatures: vec![SignatureInformation {
+            label: entry.syntax.to_string(),
+            documentation: Some(lsp_types::Documentation::String(
+                entry.description.to_string(),
+            )),
+            parameters: Some(parameters),
+            active_parameter,
+        }],
+        active_signature: Some(0),
+        active_parameter,
+    })
+}
 
 /// SignatureHelp情報を生成する
 ///

--- a/crates/ase-ls/src/server.rs
+++ b/crates/ase-ls/src/server.rs
@@ -3,8 +3,9 @@
 //! tower-lsp を使用した Language Server のハンドラー実装。
 
 use ase_ls_core::{
-    code_actions, completion, definition, diagnostics, folding, formatting, hover, references,
-    rename, semantic_tokens, signature_help, symbols, workspace_symbols,
+    analysis::DocumentAnalysis, code_actions, completion, definition, diagnostics, folding,
+    formatting, hover, references, rename, semantic_tokens, signature_help, symbols,
+    workspace_symbols,
 };
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -20,8 +21,8 @@ pub struct AseLanguageServer {
 
 /// メモリ上のドキュメント管理
 struct DocumentStore {
-    /// URI → ドキュメントテキスト
-    docs: std::collections::HashMap<String, Arc<str>>,
+    /// URI → (source, analysis)
+    docs: std::collections::HashMap<String, (Arc<str>, DocumentAnalysis)>,
 }
 
 impl DocumentStore {
@@ -32,11 +33,15 @@ impl DocumentStore {
     }
 
     fn open(&mut self, uri: &str, text: &str) {
-        self.docs.insert(uri.to_string(), Arc::from(text));
+        let analysis = DocumentAnalysis::new(text);
+        self.docs
+            .insert(uri.to_string(), (Arc::from(text), analysis));
     }
 
     fn update(&mut self, uri: &str, text: &str) {
-        self.docs.insert(uri.to_string(), Arc::from(text));
+        let analysis = DocumentAnalysis::new(text);
+        self.docs
+            .insert(uri.to_string(), (Arc::from(text), analysis));
     }
 
     fn close(&mut self, uri: &str) {
@@ -54,22 +59,18 @@ impl AseLanguageServer {
 
     /// ドキュメントの診断情報をパブリッシュする
     async fn publish_diagnostics_for(&self, uri: &Url) {
-        if let Some(source) = self.get_source(uri).await {
-            let diags = diagnostics::diagnose_source(&source);
+        if let Some(analysis) = self.get_analysis(uri).await {
+            let diags = diagnostics::diagnose(&analysis);
             self.client
                 .publish_diagnostics(uri.clone(), diags, None)
                 .await;
         }
     }
 
-    /// URIに対応するドキュメントのソーステキストを取得する
-    ///
-    /// 全ハンドラーで共通する「ドキュメント取得」パターンを集約するヘルパー。
-    /// Arc<str>によりコピーコストを最小化しつつ、RwLockの保持期間を最短にする。
-    /// 存在しない場合は None を返す。
-    async fn get_source(&self, uri: &Url) -> Option<Arc<str>> {
+    /// URIに対応するDocumentAnalysisを取得する
+    async fn get_analysis(&self, uri: &Url) -> Option<DocumentAnalysis> {
         let docs = self.documents.read().await;
-        docs.docs.get(uri.as_str()).cloned()
+        docs.docs.get(uri.as_str()).map(|(_, a)| a).cloned()
     }
 }
 
@@ -189,8 +190,8 @@ impl LanguageServer for AseLanguageServer {
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
         let uri = &params.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
-            Ok(symbols::document_symbols(&source))
+        if let Some(analysis) = self.get_analysis(uri).await {
+            Ok(symbols::document_symbols(&analysis.source))
         } else {
             Ok(None)
         }
@@ -198,8 +199,8 @@ impl LanguageServer for AseLanguageServer {
 
     async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
         let uri = &params.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
-            Ok(Some(folding::folding_ranges(&source)))
+        if let Some(analysis) = self.get_analysis(uri).await {
+            Ok(Some(folding::folding_ranges(&analysis.source)))
         } else {
             Ok(Some(Vec::new()))
         }
@@ -210,8 +211,10 @@ impl LanguageServer for AseLanguageServer {
         params: SemanticTokensParams,
     ) -> Result<Option<SemanticTokensResult>> {
         let uri = &params.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
-            Ok(Some(semantic_tokens::semantic_tokens_full(&source)))
+        if let Some(analysis) = self.get_analysis(uri).await {
+            Ok(Some(semantic_tokens::semantic_tokens_full(
+                &analysis.source,
+            )))
         } else {
             Ok(None)
         }
@@ -222,8 +225,8 @@ impl LanguageServer for AseLanguageServer {
         params: SemanticTokensRangeParams,
     ) -> Result<Option<SemanticTokensRangeResult>> {
         let uri = &params.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
-            let result = semantic_tokens::semantic_tokens_full(&source);
+        if let Some(analysis) = self.get_analysis(uri).await {
+            let result = semantic_tokens::semantic_tokens_full(&analysis.source);
             match result {
                 SemanticTokensResult::Tokens(tokens) => {
                     Ok(Some(SemanticTokensRangeResult::Tokens(tokens)))
@@ -237,9 +240,9 @@ impl LanguageServer for AseLanguageServer {
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
         let uri = &params.text_document_position_params.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
-            Ok(hover::hover(
-                &source,
+        if let Some(analysis) = self.get_analysis(uri).await {
+            Ok(hover::hover_with_analysis(
+                &analysis,
                 params.text_document_position_params.position,
             ))
         } else {
@@ -249,8 +252,8 @@ impl LanguageServer for AseLanguageServer {
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
         let uri = &params.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
-            let edits = formatting::format(&source);
+        if let Some(analysis) = self.get_analysis(uri).await {
+            let edits = formatting::format(&analysis.source);
             if edits.is_empty() {
                 Ok(None)
             } else {
@@ -266,8 +269,8 @@ impl LanguageServer for AseLanguageServer {
         params: DocumentRangeFormattingParams,
     ) -> Result<Option<Vec<TextEdit>>> {
         let uri = &params.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
-            let edits = formatting::format(&source);
+        if let Some(analysis) = self.get_analysis(uri).await {
+            let edits = formatting::format(&analysis.source);
             if edits.is_empty() {
                 Ok(None)
             } else {
@@ -280,9 +283,9 @@ impl LanguageServer for AseLanguageServer {
 
     async fn signature_help(&self, params: SignatureHelpParams) -> Result<Option<SignatureHelp>> {
         let uri = &params.text_document_position_params.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
-            Ok(signature_help::signature_help(
-                &source,
+        if let Some(analysis) = self.get_analysis(uri).await {
+            Ok(signature_help::signature_help_with_analysis(
+                &analysis,
                 params.text_document_position_params.position,
             ))
         } else {
@@ -295,9 +298,9 @@ impl LanguageServer for AseLanguageServer {
         params: GotoDefinitionParams,
     ) -> Result<Option<GotoDefinitionResponse>> {
         let uri = &params.text_document_position_params.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
-            let ranges = definition::definition_ranges(
-                &source,
+        if let Some(analysis) = self.get_analysis(uri).await {
+            let ranges = definition::definition_ranges_with_analysis(
+                &analysis,
                 params.text_document_position_params.position,
             );
             if ranges.is_empty() {
@@ -319,9 +322,9 @@ impl LanguageServer for AseLanguageServer {
 
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
         let uri = &params.text_document_position.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
+        if let Some(analysis) = self.get_analysis(uri).await {
             let ranges = references::reference_ranges(
-                &source,
+                &analysis.source,
                 params.text_document_position.position,
                 params.context.include_declaration,
             );
@@ -344,8 +347,8 @@ impl LanguageServer for AseLanguageServer {
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
         let uri = &params.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
-            let actions = code_actions::code_actions(&source, params.range, uri);
+        if let Some(analysis) = self.get_analysis(uri).await {
+            let actions = code_actions::code_actions(&analysis.source, params.range, uri);
             if actions.is_empty() {
                 Ok(None)
             } else {
@@ -358,9 +361,9 @@ impl LanguageServer for AseLanguageServer {
 
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
         let uri = &params.text_document_position.text_document.uri;
-        if let Some(source) = self.get_source(uri).await {
+        if let Some(analysis) = self.get_analysis(uri).await {
             Ok(rename::rename(
-                &source,
+                &analysis.source,
                 params.text_document_position.position,
                 &params.new_name,
                 uri,
@@ -377,7 +380,7 @@ impl LanguageServer for AseLanguageServer {
         let docs = self.documents.read().await;
         let mut all_symbols = Vec::new();
 
-        for (uri_str, source) in &docs.docs {
+        for (uri_str, (source, _analysis)) in &docs.docs {
             if let Ok(uri) = Url::parse(uri_str) {
                 let symbols = workspace_symbols::workspace_symbols(source, &params.query, &uri);
                 all_symbols.extend(symbols);


### PR DESCRIPTION
## Summary
- Add `DocumentAnalysis` struct that pre-computes LineIndex, tokens, AST, and symbol table once per source change
- Update `server.rs` `DocumentStore` to cache `DocumentAnalysis` alongside source text on `did_open`/`did_change`
- Add analysis-based overloads to diagnostics, hover, definition, and signature_help modules
- Diagnostics now uses cached parse errors (no re-parse), hover/definition use cached tokens/symbol_table

## Test plan
- [x] 911 tests passing (15 new from Phase 0-A + 0-C)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] CI green on all platforms

Closes #51, closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: glm 4.7 <noreply@zhipuai.cn>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced hover information with improved symbol context detection
  * Better definition lookup and symbol resolution
  * More consistent diagnostic error reporting across all SQL constructs
  * Improved signature help with better parameter and argument detection
  * Strengthened core language server analysis infrastructure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Protom512/tsqlremaker/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->