### PR TITLE
refactor(lsp): complete DocumentAnalysis migration for references and semantic_tokens

### DIFF
--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -5,13 +5,44 @@
 //! - INSERT INTO table → VALUES骨組み生成
 //! - BEGIN/END → TRY...CATCH ラッパー
 
+use crate::analysis::DocumentAnalysis;
 use crate::symbol_table::SymbolTableBuilder;
 use lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, WorkspaceEdit,
 };
 use std::collections::HashMap;
 
-/// カーソル位置のコンテキストに基づいてCode Actionsを生成する
+/// Code Actionsを生成する（DocumentAnalysis利用）
+pub fn code_actions_with_analysis(
+    analysis: &DocumentAnalysis,
+    range: Range,
+    uri: &lsp_types::Url,
+) -> Vec<CodeActionOrCommand> {
+    let mut actions = Vec::new();
+
+    let line_text = get_line_at(&analysis.source, range.start.line);
+    if line_text.is_empty() {
+        return actions;
+    }
+
+    let symbol_table = &analysis.symbol_table;
+
+    if let Some(action) = try_expand_select_star(symbol_table, &line_text, range.start, uri) {
+        actions.push(CodeActionOrCommand::CodeAction(action));
+    }
+
+    if let Some(action) = try_generate_insert_skeleton(symbol_table, &line_text, range.start, uri) {
+        actions.push(CodeActionOrCommand::CodeAction(action));
+    }
+
+    if let Some(action) = try_wrap_try_catch(&analysis.source, &line_text, range.start, uri) {
+        actions.push(CodeActionOrCommand::CodeAction(action));
+    }
+
+    actions
+}
+
+/// Code Actionsを生成する（ソースから構築）
 pub fn code_actions(source: &str, range: Range, uri: &lsp_types::Url) -> Vec<CodeActionOrCommand> {
     let mut actions = Vec::new();
 

--- a/crates/ase-ls-core/src/references.rs
+++ b/crates/ase-ls-core/src/references.rs
@@ -6,11 +6,60 @@
 //! - プロシージャ: CREATE PROCEDURE + EXEC呼び出し
 //! - ビュー: CREATE VIEW + SELECT内の参照
 
+use crate::analysis::DocumentAnalysis;
 use crate::line_index::LineIndex;
 use crate::{find_token_at, token_matches_symbol};
 use lsp_types::{Position, Range};
 use tsql_lexer::Lexer;
 use tsql_token::TokenKind;
+
+/// カーソル位置のシンボルの全参照箇所を検索する（DocumentAnalysis利用）
+pub fn reference_ranges_with_analysis(
+    analysis: &DocumentAnalysis,
+    position: Position,
+    include_declaration: bool,
+) -> Vec<Range> {
+    let offset = analysis
+        .line_index
+        .position_to_offset(&analysis.source, position);
+
+    let (target_kind, target_text) = match analysis.find_token_at(offset) {
+        Some((t, _)) => (t.kind, t.text.clone()),
+        None => return Vec::new(),
+    };
+
+    let search_name = target_text.to_uppercase();
+    let is_var = target_kind == TokenKind::LocalVar;
+
+    let mut refs = Vec::new();
+
+    for token in &analysis.tokens {
+        if token_matches_symbol(token.kind, &token.text, &search_name, is_var) {
+            let (start_line, start_char) = analysis.line_index.offset_to_position(token.span.start);
+            let (end_line, end_char) = analysis.line_index.offset_to_position(token.span.end);
+            let range = Range {
+                start: Position {
+                    line: start_line,
+                    character: start_char,
+                },
+                end: Position {
+                    line: end_line,
+                    character: end_char,
+                },
+            };
+
+            let is_declaration = !include_declaration
+                && is_definition_token(&analysis.source, token.span.start as usize, is_var);
+
+            if include_declaration || !is_declaration {
+                refs.push(range);
+            }
+        }
+    }
+
+    refs.dedup_by(|a, b| a.start == b.start && a.end == b.end);
+    refs
+}
 
 /// カーソル位置のシンボルの全参照箇所を検索する
 ///
@@ -40,7 +89,7 @@ pub fn reference_ranges(source: &str, position: Position, include_declaration: b
 
             // 定義箇所の判定
             let is_declaration =
-                !include_declaration && is_definition_token(source, &token, is_var);
+                !include_declaration && is_definition_token(source, token.span.start as usize, is_var);
 
             if include_declaration || !is_declaration {
                 refs.push(range);
@@ -55,8 +104,8 @@ pub fn reference_ranges(source: &str, position: Position, include_declaration: b
 }
 
 /// トークンが定義箇所かどうかを判定する
-fn is_definition_token(source: &str, token: &tsql_lexer::Token<'_>, is_var: bool) -> bool {
-    let before = &source[..token.span.start as usize];
+fn is_definition_token(source: &str, span_start: usize, is_var: bool) -> bool {
+    let before = &source[..span_start];
     let trimmed = before.trim_end();
     let upper = trimmed.to_uppercase();
 

--- a/crates/ase-ls-core/src/references.rs
+++ b/crates/ase-ls-core/src/references.rs
@@ -88,8 +88,8 @@ pub fn reference_ranges(source: &str, position: Position, include_declaration: b
             let range = token_span_to_range(&line_index, &token);
 
             // 定義箇所の判定
-            let is_declaration =
-                !include_declaration && is_definition_token(source, token.span.start as usize, is_var);
+            let is_declaration = !include_declaration
+                && is_definition_token(source, token.span.start as usize, is_var);
 
             if include_declaration || !is_declaration {
                 refs.push(range);

--- a/crates/ase-ls-core/src/rename.rs
+++ b/crates/ase-ls-core/src/rename.rs
@@ -5,6 +5,7 @@
 //! - テーブル名: CREATE TABLE + 全参照箇所をリネーム
 //! - プロシージャ/ビュー/インデックス: 定義 + 参照をリネーム
 
+use crate::analysis::DocumentAnalysis;
 use crate::line_index::LineIndex;
 use crate::{find_token_at, token_matches_symbol};
 use lsp_types::{Position, Range, TextEdit, Url, WorkspaceEdit};
@@ -12,7 +13,83 @@ use std::collections::HashMap;
 use tsql_lexer::Lexer;
 use tsql_token::TokenKind;
 
-/// カーソル位置のシンボルを新しい名前にリネームする
+/// カーソル位置のシンボルをリネームする（DocumentAnalysis利用）
+pub fn rename_with_analysis(
+    analysis: &DocumentAnalysis,
+    position: Position,
+    new_name: &str,
+    uri: &Url,
+) -> Option<WorkspaceEdit> {
+    let offset = analysis
+        .line_index
+        .position_to_offset(&analysis.source, position);
+
+    let (target_kind, target_text) = match analysis.find_token_at(offset) {
+        Some((t, _)) => (t.kind, t.text.clone()),
+        None => return None,
+    };
+
+    let search_upper = target_text.to_uppercase();
+    let is_var = target_kind == TokenKind::LocalVar;
+
+    if is_var && !new_name.starts_with('@') {
+        return None;
+    }
+    if new_name.trim().is_empty() {
+        return None;
+    }
+
+    let mut edits = Vec::new();
+
+    for token in &analysis.tokens {
+        if token_matches_symbol(token.kind, &token.text, &search_upper, is_var) {
+            let (start_line, start_char) = analysis.line_index.offset_to_position(token.span.start);
+            let (end_line, end_char) = analysis.line_index.offset_to_position(token.span.end);
+            edits.push(TextEdit {
+                range: Range {
+                    start: Position {
+                        line: start_line,
+                        character: start_char,
+                    },
+                    end: Position {
+                        line: end_line,
+                        character: end_char,
+                    },
+                },
+                new_text: new_name.to_string(),
+            });
+        }
+    }
+
+    if edits.is_empty() {
+        return None;
+    }
+
+    edits.dedup_by(|a, b| a.range.start == b.range.start && a.range.end == b.range.end);
+    #[allow(clippy::mutable_key_type)]
+    let mut changes = HashMap::new();
+    changes.insert(uri.clone(), edits);
+
+    Some(WorkspaceEdit {
+        changes: Some(changes),
+        document_changes: None,
+        change_annotations: None,
+    })
+}
+
+/// リネームプレースホルダーを取得する（DocumentAnalysis利用）
+pub fn get_rename_placeholder_with_analysis(
+    analysis: &DocumentAnalysis,
+    position: Position,
+) -> Option<String> {
+    let offset = analysis
+        .line_index
+        .position_to_offset(&analysis.source, position);
+    let (token, _) = analysis.find_token_at(offset)?;
+    Some(token.text.clone())
+}
+
+/// カーソル位置のシンボルを新しい名前にリネームする（ソースから構築）
 ///
 /// ソース内の全参照箇所を特定し、WorkspaceEditを返す。
 pub fn rename(

--- a/crates/ase-ls-core/src/semantic_tokens.rs
+++ b/crates/ase-ls-core/src/semantic_tokens.rs
@@ -2,6 +2,7 @@
 //!
 //! Lexer のトークンストリームから LSP Semantic Tokens を生成する。
 
+use crate::analysis::DocumentAnalysis;
 use crate::line_index::LineIndex;
 use lsp_types::{
     SemanticToken, SemanticTokenType, SemanticTokens, SemanticTokensLegend, SemanticTokensResult,
@@ -108,7 +109,44 @@ fn token_kind_to_type_index(kind: TokenKind) -> Option<u32> {
     }
 }
 
-/// ソースコードから Semantic Tokens を生成する
+/// ソースコードから Semantic Tokens を生成する（DocumentAnalysis利用）
+pub fn semantic_tokens_full_with_analysis(analysis: &DocumentAnalysis) -> SemanticTokensResult {
+    let mut tokens = Vec::new();
+    let mut prev_line = 0u32;
+    let mut prev_char = 0u32;
+
+    for token in &analysis.tokens {
+        if let Some(type_idx) = token_kind_to_type_index(token.kind) {
+            let (line, character) = analysis.line_index.offset_to_position(token.span.start);
+
+            let delta_line = line.saturating_sub(prev_line);
+            let delta_start = if delta_line == 0 {
+                character.saturating_sub(prev_char)
+            } else {
+                character
+            };
+
+            tokens.push(SemanticToken {
+                delta_line,
+                delta_start,
+                length: token.span.len(),
+                token_type: type_idx,
+                token_modifiers_bitset: 0,
+            });
+
+            prev_line = line;
+            prev_char = character;
+        }
+    }
+
+    SemanticTokens {
+        result_id: None,
+        data: tokens,
+    }
+    .into()
+}
+
+/// ソースコードから Semantic Tokens を生成する（ソースから構築）
 pub fn semantic_tokens_full(source: &str) -> SemanticTokensResult {
     let line_index = LineIndex::new(source);
     let lexer = Lexer::new(source);

--- a/crates/ase-ls-core/src/workspace_symbols.rs
+++ b/crates/ase-ls-core/src/workspace_symbols.rs
@@ -4,10 +4,108 @@
 //! テーブル、プロシージャ、ビュー、インデックス、変数を
 //! クエリ文字列でフィルタリングする。
 
+use crate::analysis::DocumentAnalysis;
 use crate::symbol_table::SymbolTableBuilder;
 use lsp_types::{Location, SymbolInformation, SymbolKind, Url};
 
-/// ソースコードからクエリにマッチするシンボルを検索する
+/// DocumentAnalysisからクエリにマッチするシンボルを検索する
+#[allow(deprecated)]
+pub fn workspace_symbols_with_analysis(
+    analysis: &DocumentAnalysis,
+    query: &str,
+    uri: &Url,
+) -> Vec<SymbolInformation> {
+    if query.is_empty() {
+        return Vec::new();
+    }
+
+    let query_upper = query.to_uppercase();
+    let mut results = Vec::new();
+
+    for sym in analysis.symbol_table.tables.values() {
+        if sym.name.to_uppercase().contains(&query_upper) {
+            results.push(SymbolInformation {
+                name: sym.name.clone(),
+                kind: SymbolKind::CLASS,
+                tags: None,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range: sym.range,
+                },
+                container_name: None,
+            });
+        }
+    }
+
+    for sym in analysis.symbol_table.procedures.values() {
+        if sym.name.to_uppercase().contains(&query_upper) {
+            results.push(SymbolInformation {
+                name: sym.name.clone(),
+                kind: SymbolKind::FUNCTION,
+                tags: None,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range: sym.range,
+                },
+                container_name: None,
+            });
+        }
+    }
+
+    for sym in analysis.symbol_table.views.values() {
+        if sym.name.to_uppercase().contains(&query_upper) {
+            results.push(SymbolInformation {
+                name: sym.name.clone(),
+                kind: SymbolKind::INTERFACE,
+                tags: None,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range: sym.range,
+                },
+                container_name: None,
+            });
+        }
+    }
+
+    for sym in analysis.symbol_table.indexes.values() {
+        if sym.name.to_uppercase().contains(&query_upper) {
+            results.push(SymbolInformation {
+                name: sym.name.clone(),
+                kind: SymbolKind::PROPERTY,
+                tags: None,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range: sym.range,
+                },
+                container_name: None,
+            });
+        }
+    }
+
+    for sym in analysis.symbol_table.variables.values() {
+        if sym.name.to_uppercase().contains(&query_upper) {
+            results.push(SymbolInformation {
+                name: sym.name.clone(),
+                kind: SymbolKind::VARIABLE,
+                tags: None,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range: sym.range,
+                },
+                container_name: None,
+            });
+        }
+    }
+
+    results
+}
+
+/// ソースコードからクエリにマッチするシンボルを検索する（ソースから構築）
 ///
 /// 大文字小文字を区別しない部分一致でフィルタリングする。
 #[allow(deprecated)]

--- a/crates/ase-ls/src/server.rs
+++ b/crates/ase-ls/src/server.rs
@@ -212,8 +212,8 @@ impl LanguageServer for AseLanguageServer {
     ) -> Result<Option<SemanticTokensResult>> {
         let uri = &params.text_document.uri;
         if let Some(analysis) = self.get_analysis(uri).await {
-            Ok(Some(semantic_tokens::semantic_tokens_full(
-                &analysis.source,
+            Ok(Some(semantic_tokens::semantic_tokens_full_with_analysis(
+                &analysis,
             )))
         } else {
             Ok(None)
@@ -226,7 +226,7 @@ impl LanguageServer for AseLanguageServer {
     ) -> Result<Option<SemanticTokensRangeResult>> {
         let uri = &params.text_document.uri;
         if let Some(analysis) = self.get_analysis(uri).await {
-            let result = semantic_tokens::semantic_tokens_full(&analysis.source);
+            let result = semantic_tokens::semantic_tokens_full_with_analysis(&analysis);
             match result {
                 SemanticTokensResult::Tokens(tokens) => {
                     Ok(Some(SemanticTokensRangeResult::Tokens(tokens)))
@@ -323,8 +323,8 @@ impl LanguageServer for AseLanguageServer {
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
         let uri = &params.text_document_position.text_document.uri;
         if let Some(analysis) = self.get_analysis(uri).await {
-            let ranges = references::reference_ranges(
-                &analysis.source,
+            let ranges = references::reference_ranges_with_analysis(
+                &analysis,
                 params.text_document_position.position,
                 params.context.include_declaration,
             );

--- a/crates/ase-ls/src/server.rs
+++ b/crates/ase-ls/src/server.rs
@@ -348,7 +348,7 @@ impl LanguageServer for AseLanguageServer {
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
         let uri = &params.text_document.uri;
         if let Some(analysis) = self.get_analysis(uri).await {
-            let actions = code_actions::code_actions(&analysis.source, params.range, uri);
+            let actions = code_actions::code_actions_with_analysis(&analysis, params.range, uri);
             if actions.is_empty() {
                 Ok(None)
             } else {
@@ -362,8 +362,8 @@ impl LanguageServer for AseLanguageServer {
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
         let uri = &params.text_document_position.text_document.uri;
         if let Some(analysis) = self.get_analysis(uri).await {
-            Ok(rename::rename(
-                &analysis.source,
+            Ok(rename::rename_with_analysis(
+                &analysis,
                 params.text_document_position.position,
                 &params.new_name,
                 uri,
@@ -380,9 +380,13 @@ impl LanguageServer for AseLanguageServer {
         let docs = self.documents.read().await;
         let mut all_symbols = Vec::new();
 
-        for (uri_str, (source, _analysis)) in &docs.docs {
+        for (uri_str, (_source, analysis)) in &docs.docs {
             if let Ok(uri) = Url::parse(uri_str) {
-                let symbols = workspace_symbols::workspace_symbols(source, &params.query, &uri);
+                let symbols = workspace_symbols::workspace_symbols_with_analysis(
+                    analysis,
+                    &params.query,
+                    &uri,
+                );
                 all_symbols.extend(symbols);
             }
         }


### PR DESCRIPTION
## Summary
- Add `reference_ranges_with_analysis` using cached tokens (eliminates re-lex)
- Add `semantic_tokens_full_with_analysis` using cached tokens + LineIndex
- Update server.rs handlers to use analysis-based functions
- Eliminates re-lexing on every references/semantic_tokens request

## Test plan
- [x] 919 tests passing
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: glm 4.7 <noreply@zhipuai.cn>