### PR TITLE
perf(lsp): O(1) get_line via LineIndex (#66)

### DIFF
--- a/crates/ase-ls-core/src/analysis.rs
+++ b/crates/ase-ls-core/src/analysis.rs
@@ -109,6 +109,23 @@ impl DocumentAnalysis {
             None
         }
     }
+
+    /// Get the text of a specific line. O(1) line lookup via LineIndex.
+    pub fn get_line(&self, line: u32) -> &str {
+        let line_count = self.line_index.line_count();
+        let line = line as usize;
+        if line >= line_count {
+            return "";
+        }
+        let start = self.line_index.line_offset(line);
+        let end = if line + 1 < line_count {
+            self.line_index.line_offset(line + 1)
+        } else {
+            self.source.len()
+        };
+        let line_text = &self.source[start..end];
+        line_text.trim_end_matches('\n').trim_end_matches('\r')
+    }
 }
 
 #[cfg(test)]
@@ -204,5 +221,49 @@ mod tests {
         let (token, _) = analysis.find_token_at(8).unwrap();
         assert_eq!(token.kind, TokenKind::LocalVar);
         assert_eq!(token.text, "@count");
+    }
+
+    // --- get_line() tests (Phase 2-C: O(1) line lookup) ---
+
+    #[test]
+    fn test_get_line_single_line() {
+        let analysis = DocumentAnalysis::new("SELECT * FROM users");
+        assert_eq!(analysis.get_line(0), "SELECT * FROM users");
+    }
+
+    #[test]
+    fn test_get_line_multi_line() {
+        let analysis = DocumentAnalysis::new("SELECT *\nFROM users\nWHERE id = 1");
+        assert_eq!(analysis.get_line(0), "SELECT *");
+        assert_eq!(analysis.get_line(1), "FROM users");
+        assert_eq!(analysis.get_line(2), "WHERE id = 1");
+    }
+
+    #[test]
+    fn test_get_line_out_of_range_returns_empty() {
+        let analysis = DocumentAnalysis::new("SELECT *");
+        assert_eq!(analysis.get_line(5), "");
+    }
+
+    #[test]
+    fn test_get_line_empty_source() {
+        let analysis = DocumentAnalysis::new("");
+        assert_eq!(analysis.get_line(0), "");
+    }
+
+    #[test]
+    fn test_get_line_trailing_newline() {
+        let analysis = DocumentAnalysis::new("line1\nline2\n");
+        assert_eq!(analysis.get_line(0), "line1");
+        assert_eq!(analysis.get_line(1), "line2");
+        // trailing newline creates an empty line 2
+        assert_eq!(analysis.get_line(2), "");
+    }
+
+    #[test]
+    fn test_get_line_crlf() {
+        let analysis = DocumentAnalysis::new("line1\r\nline2");
+        assert_eq!(analysis.get_line(0), "line1");
+        assert_eq!(analysis.get_line(1), "line2");
     }
 }

--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -20,7 +20,7 @@ pub fn code_actions_with_analysis(
 ) -> Vec<CodeActionOrCommand> {
     let mut actions = Vec::new();
 
-    let line_text = get_line_at(&analysis.source, range.start.line);
+    let line_text = analysis.get_line(range.start.line).to_string();
     if line_text.is_empty() {
         return actions;
     }

--- a/crates/ase-ls-core/src/line_index.rs
+++ b/crates/ase-ls-core/src/line_index.rs
@@ -59,9 +59,13 @@ impl LineIndex {
     }
 
     /// Get the number of lines.
-    #[cfg(test)]
-    pub(crate) fn line_count(&self) -> usize {
+    pub fn line_count(&self) -> usize {
         self.line_offsets.len()
+    }
+
+    /// Get the byte offset of the start of a line. O(1).
+    pub fn line_offset(&self, line: usize) -> usize {
+        self.line_offsets.get(line).copied().unwrap_or(0) as usize
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `LineIndex::line_offset()` and make `line_count()` public for O(1) line byte offset lookup
- Add `DocumentAnalysis::get_line(line)` using pre-computed offsets instead of O(n) source scan
- Migrate `code_actions_with_analysis` to use the new `analysis.get_line()` method

## Test plan
- [x] 6 new tests for `get_line()` (single line, multi-line, out-of-range, empty, trailing newline, CRLF)
- [x] `cargo nextest run --workspace` — 925 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved code analysis performance through optimized internal line data retrieval and indexing operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Protom512/tsqlremaker/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->