### PR TITLE
feat(lsp): add prepareRename validation (#67)

### DIFF
--- a/crates/ase-ls-core/src/rename.rs
+++ b/crates/ase-ls-core/src/rename.rs
@@ -8,7 +8,7 @@
 use crate::analysis::DocumentAnalysis;
 use crate::line_index::LineIndex;
 use crate::{find_token_at, token_matches_symbol};
-use lsp_types::{Position, Range, TextEdit, Url, WorkspaceEdit};
+use lsp_types::{Position, PrepareRenameResponse, Range, TextEdit, Url, WorkspaceEdit};
 use std::collections::HashMap;
 use tsql_lexer::Lexer;
 use tsql_token::TokenKind;
@@ -87,6 +87,47 @@ pub fn get_rename_placeholder_with_analysis(
         .position_to_offset(&analysis.source, position);
     let (token, _) = analysis.find_token_at(offset)?;
     Some(token.text.clone())
+}
+
+/// カーソル位置がリネーム可能か検証する（DocumentAnalysis利用）
+///
+/// リネーム可能なトークン種別のみ許可し、キーワード・文字列・空白は拒否する。
+/// prepareRename LSPリクエストのハンドラとして使用する。
+pub fn prepare_rename_with_analysis(
+    analysis: &DocumentAnalysis,
+    position: Position,
+) -> Option<PrepareRenameResponse> {
+    let offset = analysis
+        .line_index
+        .position_to_offset(&analysis.source, position);
+
+    let (token, _) = analysis.find_token_at(offset)?;
+
+    let is_renamable = matches!(
+        token.kind,
+        TokenKind::Ident | TokenKind::LocalVar | TokenKind::GlobalVar
+    );
+
+    if !is_renamable {
+        return None;
+    }
+
+    let (start_line, start_char) = analysis.line_index.offset_to_position(token.span.start);
+    let (end_line, end_char) = analysis.line_index.offset_to_position(token.span.end);
+
+    Some(PrepareRenameResponse::RangeWithPlaceholder {
+        range: Range {
+            start: Position {
+                line: start_line,
+                character: start_char,
+            },
+            end: Position {
+                line: end_line,
+                character: end_char,
+            },
+        },
+        placeholder: token.text.clone(),
+    })
 }
 
 /// カーソル位置のシンボルを新しい名前にリネームする（ソースから構築）
@@ -400,6 +441,104 @@ mod tests {
                 te.range.end.character > te.range.start.character
                     || te.range.end.line > te.range.start.line
             );
+        }
+    }
+
+    // --- prepare_rename tests ---
+
+    #[test]
+    fn test_prepare_rename_on_identifier() {
+        let analysis = DocumentAnalysis::new("SELECT * FROM users");
+        let result = prepare_rename_with_analysis(
+            &analysis,
+            Position {
+                line: 0,
+                character: 15,
+            },
+        );
+        assert!(result.is_some());
+        match result {
+            Some(PrepareRenameResponse::RangeWithPlaceholder { placeholder, .. }) => {
+                assert_eq!(placeholder, "users");
+            }
+            _ => panic!("Expected RangeWithPlaceholder"),
+        }
+    }
+
+    #[test]
+    fn test_prepare_rename_on_variable() {
+        let analysis = DocumentAnalysis::new("DECLARE @count INT\nSET @count = 1");
+        let result = prepare_rename_with_analysis(
+            &analysis,
+            Position {
+                line: 0,
+                character: 9,
+            },
+        );
+        assert!(result.is_some());
+        match result {
+            Some(PrepareRenameResponse::RangeWithPlaceholder { placeholder, .. }) => {
+                assert_eq!(placeholder, "@count");
+            }
+            _ => panic!("Expected RangeWithPlaceholder"),
+        }
+    }
+
+    #[test]
+    fn test_prepare_rename_on_keyword_rejected() {
+        let analysis = DocumentAnalysis::new("SELECT * FROM users");
+        let result = prepare_rename_with_analysis(
+            &analysis,
+            Position {
+                line: 0,
+                character: 2,
+            },
+        );
+        assert!(result.is_none(), "Keywords should not be renamable");
+    }
+
+    #[test]
+    fn test_prepare_rename_on_whitespace_rejected() {
+        let analysis = DocumentAnalysis::new("SELECT  FROM t");
+        let result = prepare_rename_with_analysis(
+            &analysis,
+            Position {
+                line: 0,
+                character: 7,
+            },
+        );
+        assert!(result.is_none(), "Whitespace should not be renamable");
+    }
+
+    #[test]
+    fn test_prepare_rename_on_string_rejected() {
+        let analysis = DocumentAnalysis::new("SELECT 'hello' FROM t");
+        let result = prepare_rename_with_analysis(
+            &analysis,
+            Position {
+                line: 0,
+                character: 9,
+            },
+        );
+        assert!(result.is_none(), "String literals should not be renamable");
+    }
+
+    #[test]
+    fn test_prepare_rename_returns_valid_range() {
+        let analysis = DocumentAnalysis::new("SELECT * FROM users");
+        let result = prepare_rename_with_analysis(
+            &analysis,
+            Position {
+                line: 0,
+                character: 15,
+            },
+        );
+        match result {
+            Some(PrepareRenameResponse::RangeWithPlaceholder { range, .. }) => {
+                assert_eq!(range.start.line, 0);
+                assert!(range.start.character < range.end.character);
+            }
+            _ => panic!("Expected RangeWithPlaceholder"),
         }
     }
 }

--- a/crates/ase-ls/src/server.rs
+++ b/crates/ase-ls/src/server.rs
@@ -124,7 +124,12 @@ impl LanguageServer for AseLanguageServer {
                 references_provider: Some(OneOf::Left(true)),
                 workspace_symbol_provider: Some(OneOf::Left(true)),
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
-                rename_provider: Some(OneOf::Left(true)),
+                rename_provider: Some(OneOf::Right(RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: None,
+                    },
+                })),
                 ..ServerCapabilities::default()
             },
             server_info: Some(ServerInfo {
@@ -367,6 +372,21 @@ impl LanguageServer for AseLanguageServer {
                 params.text_document_position.position,
                 &params.new_name,
                 uri,
+            ))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn prepare_rename(
+        &self,
+        params: TextDocumentPositionParams,
+    ) -> Result<Option<PrepareRenameResponse>> {
+        let uri = &params.text_document.uri;
+        if let Some(analysis) = self.get_analysis(uri).await {
+            Ok(rename::prepare_rename_with_analysis(
+                &analysis,
+                params.position,
             ))
         } else {
             Ok(None)


### PR DESCRIPTION
## Summary
- Add `prepare_rename_with_analysis()` to validate renamable tokens before showing rename UI
- Only `Ident`, `LocalVar`, `GlobalVar` tokens are renamable — keywords, strings, whitespace rejected
- Server capabilities updated to `RenameOptions` with `prepare_provider: true`
- Returns `PrepareRenameResponse::RangeWithPlaceholder` with range and current name

## Test plan
- [x] 6 new tests: identifier, variable, keyword rejection, whitespace rejection, string rejection, valid range
- [x] `cargo nextest run --workspace` — 932 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)