### PR TITLE
feat(lsp): AST-aware folding ranges (#76)

### DIFF
--- a/crates/ase-ls-core/src/folding.rs
+++ b/crates/ase-ls-core/src/folding.rs
@@ -5,6 +5,7 @@
 use crate::line_index::LineIndex;
 use lsp_types::{FoldingRange, FoldingRangeKind};
 use tsql_lexer::Lexer;
+use tsql_parser::ast::Statement;
 use tsql_token::TokenKind;
 
 /// ソースコードから Folding Ranges を生成する
@@ -19,6 +20,134 @@ pub fn folding_ranges(source: &str) -> Vec<FoldingRange> {
     ranges.extend(fold_begin_end(&line_index, source));
 
     ranges
+}
+
+/// Folding Ranges を DocumentAnalysis から生成する（AST対応版）
+pub fn folding_ranges_with_analysis(
+    analysis: &crate::analysis::DocumentAnalysis,
+) -> Vec<FoldingRange> {
+    let mut ranges = Vec::new();
+
+    // 1. Block comments (token-level)
+    ranges.extend(fold_comments(&analysis.line_index, &analysis.source));
+
+    // 2. AST-based folding: walk statements for foldable structures
+    for stmt in &analysis.statements {
+        collect_ast_folds(stmt, analysis, &mut ranges);
+    }
+
+    ranges
+}
+
+/// Recursively walk statements to find foldable regions.
+fn collect_ast_folds(
+    stmt: &Statement,
+    analysis: &crate::analysis::DocumentAnalysis,
+    ranges: &mut Vec<FoldingRange>,
+) {
+    match stmt {
+        Statement::Block(block) => {
+            let start = block.span.start as usize;
+            let end = block.span.end as usize;
+            add_fold_if_multiline(start, end, analysis, ranges);
+            for child in &block.statements {
+                collect_ast_folds(child, analysis, ranges);
+            }
+        }
+        Statement::If(if_stmt) => {
+            // Fold the entire IF...ELSE
+            let start = if_stmt.span.start as usize;
+            let end = if_stmt.span.end as usize;
+            add_fold_if_multiline(start, end, analysis, ranges);
+            // Also recurse into branches for nested folds
+            collect_ast_folds(&if_stmt.then_branch, analysis, ranges);
+            if let Some(else_branch) = &if_stmt.else_branch {
+                collect_ast_folds(else_branch, analysis, ranges);
+            }
+        }
+        Statement::While(while_stmt) => {
+            let start = while_stmt.span.start as usize;
+            let end = while_stmt.span.end as usize;
+            add_fold_if_multiline(start, end, analysis, ranges);
+            collect_ast_folds(&while_stmt.body, analysis, ranges);
+        }
+        Statement::TryCatch(try_catch) => {
+            // Fold TRY block
+            let try_start = try_catch.try_block.span.start as usize;
+            let try_end = try_catch.try_block.span.end as usize;
+            add_fold_if_multiline(try_start, try_end, analysis, ranges);
+            for child in &try_catch.try_block.statements {
+                collect_ast_folds(child, analysis, ranges);
+            }
+            // Fold CATCH block
+            let catch_start = try_catch.catch_block.span.start as usize;
+            let catch_end = try_catch.catch_block.span.end as usize;
+            add_fold_if_multiline(catch_start, catch_end, analysis, ranges);
+            for child in &try_catch.catch_block.statements {
+                collect_ast_folds(child, analysis, ranges);
+            }
+        }
+        Statement::Create(create) => {
+            if let tsql_parser::ast::CreateStatement::Procedure(proc) = create.as_ref() {
+                // Fold procedure body if multi-line
+                let start = proc.span.start as usize;
+                let end = proc.span.end as usize;
+                add_fold_if_multiline(start, end, analysis, ranges);
+            }
+        }
+        // For other statements with nested bodies, recurse into children
+        Statement::Select(_)
+        | Statement::Insert(_)
+        | Statement::Update(_)
+        | Statement::Delete(_)
+        | Statement::Declare(_)
+        | Statement::Set(_)
+        | Statement::VariableAssignment(_)
+        | Statement::Break(_)
+        | Statement::Continue(_)
+        | Statement::Return(_)
+        | Statement::Transaction(_)
+        | Statement::Throw(_)
+        | Statement::Raiserror(_)
+        | Statement::BatchSeparator(_) => {}
+    }
+}
+
+fn add_fold_if_multiline(
+    start_offset: usize,
+    end_offset: usize,
+    analysis: &crate::analysis::DocumentAnalysis,
+    ranges: &mut Vec<FoldingRange>,
+) {
+    let end = if end_offset == 0 || end_offset <= start_offset {
+        // Parser produced broken span — fall back to token-based end detection.
+        // Find the last token whose start is >= start_offset.
+        let last_token = analysis
+            .tokens
+            .iter()
+            .rev()
+            .find(|t| t.span.start as usize >= start_offset);
+        match last_token {
+            Some(t) => t.span.end as usize,
+            None => return,
+        }
+    } else {
+        end_offset
+    };
+
+    let (start_line, _) = analysis.line_index.offset_to_position(start_offset as u32);
+    let (end_line, _) = analysis.line_index.offset_to_position(end as u32);
+
+    if start_line < end_line {
+        ranges.push(FoldingRange {
+            start_line,
+            start_character: None,
+            end_line,
+            end_character: None,
+            kind: Some(FoldingRangeKind::Region),
+            collapsed_text: None,
+        });
+    }
 }
 
 /// ブロックコメントの折りたたみ範囲を検出
@@ -134,5 +263,78 @@ mod tests {
             .filter(|r| r.kind == Some(FoldingRangeKind::Comment))
             .collect();
         assert!(comment_folds.is_empty());
+    }
+
+    // === AST folding tests (#76) ===
+
+    fn make_analysis(source: &str) -> crate::analysis::DocumentAnalysis {
+        crate::analysis::DocumentAnalysis::new(source)
+    }
+
+    fn count_region_folds(ranges: &[FoldingRange]) -> usize {
+        ranges
+            .iter()
+            .filter(|r| r.kind == Some(FoldingRangeKind::Region))
+            .count()
+    }
+
+    #[test]
+    fn test_ast_fold_if_else_no_begin() {
+        let source = "IF 1 = 1\n    SELECT 1\nELSE\n    SELECT 2";
+        let analysis = make_analysis(source);
+        let ranges = folding_ranges_with_analysis(&analysis);
+        let region_folds = count_region_folds(&ranges);
+        assert!(
+            region_folds >= 1,
+            "IF/ELSE without BEGIN should produce at least 1 region fold via AST, got {region_folds}"
+        );
+    }
+
+    #[test]
+    fn test_ast_fold_while_no_begin() {
+        let source = "WHILE @count < 10\n    SELECT @count";
+        let analysis = make_analysis(source);
+        let ranges = folding_ranges_with_analysis(&analysis);
+        let region_folds = count_region_folds(&ranges);
+        assert!(
+            region_folds >= 1,
+            "WHILE without BEGIN should produce at least 1 region fold via AST, got {region_folds}"
+        );
+    }
+
+    #[test]
+    fn test_ast_fold_if_multiline() {
+        let source = "IF @x > 0\n    INSERT INTO t VALUES (@x)\n    DELETE FROM t WHERE id = @x";
+        let analysis = make_analysis(source);
+        let ranges = folding_ranges_with_analysis(&analysis);
+        let region_folds = count_region_folds(&ranges);
+        assert!(
+            region_folds >= 1,
+            "Multi-line IF body should be foldable via AST, got {region_folds}"
+        );
+    }
+
+    #[test]
+    fn test_ast_fold_if_else_with_begin_extra_fold() {
+        let source = "IF 1 = 1\nBEGIN\n    SELECT 1\nEND\nELSE\nBEGIN\n    SELECT 2\nEND";
+        let analysis = make_analysis(source);
+        let ranges = folding_ranges_with_analysis(&analysis);
+        let region_folds = count_region_folds(&ranges);
+        assert!(
+            region_folds >= 3,
+            "IF/ELSE with BEGIN should produce 3+ folds (IF + 2 BEGIN blocks), got {region_folds}"
+        );
+    }
+
+    #[test]
+    fn test_ast_fold_preserves_comment_folds() {
+        let source = "/* multi-line\n   comment */\nSELECT 1";
+        let analysis = make_analysis(source);
+        let ranges = folding_ranges_with_analysis(&analysis);
+        let comment_folds: Vec<_> = ranges
+            .iter()
+            .filter(|r| r.kind == Some(FoldingRangeKind::Comment))
+            .collect();
+        assert_eq!(comment_folds.len(), 1, "comment folds should be preserved");
     }
 }

--- a/crates/ase-ls/src/server.rs
+++ b/crates/ase-ls/src/server.rs
@@ -205,7 +205,7 @@ impl LanguageServer for AseLanguageServer {
     async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
         let uri = &params.text_document.uri;
         if let Some(analysis) = self.get_analysis(uri).await {
-            Ok(Some(folding::folding_ranges(&analysis.source)))
+            Ok(Some(folding::folding_ranges_with_analysis(&analysis)))
         } else {
             Ok(Some(Vec::new()))
         }

--- a/crates/ase-ls/tests/integration.rs
+++ b/crates/ase-ls/tests/integration.rs
@@ -226,3 +226,104 @@ async fn test_did_close_clears_document() {
         "Should return response even after close"
     );
 }
+
+// --- Folding Range tests (#76 AST-aware integration) ---
+
+#[tokio::test]
+async fn test_folding_range_begin_end() {
+    let mut service = setup();
+    init_and_open(
+        &mut service,
+        "file:///test.sql",
+        "BEGIN\n    SELECT 1\n    SELECT 2\nEND",
+    )
+    .await;
+
+    let req = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/foldingRange",
+        "params": {
+            "textDocument": { "uri": "file:///test.sql" }
+        }
+    });
+    let response = send(&mut service, &req.to_string()).await;
+
+    assert!(response.is_some(), "Should return folding ranges");
+    let result = response.unwrap();
+    let result_val: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&result.result()).unwrap()).unwrap();
+    let ranges = result_val
+        .as_array()
+        .expect("folding ranges should be array");
+    assert!(
+        ranges
+            .iter()
+            .any(|r| r.get("kind").is_some_and(|k| k == "region")),
+        "Should contain at least one region fold for BEGIN...END"
+    );
+}
+
+#[tokio::test]
+async fn test_folding_range_if_without_begin() {
+    let mut service = setup();
+    // IF/ELSE without BEGIN — only AST-based folding detects this
+    init_and_open(
+        &mut service,
+        "file:///test.sql",
+        "IF 1 = 1\n    SELECT 1\nELSE\n    SELECT 2",
+    )
+    .await;
+
+    let req = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/foldingRange",
+        "params": {
+            "textDocument": { "uri": "file:///test.sql" }
+        }
+    });
+    let response = send(&mut service, &req.to_string()).await;
+
+    assert!(response.is_some(), "Should return folding ranges");
+    let result = response.unwrap();
+    let result_val: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&result.result()).unwrap()).unwrap();
+    let ranges = result_val
+        .as_array()
+        .expect("folding ranges should be array");
+    // Old token-based folding cannot detect IF without BEGIN — only AST path finds this
+    assert!(
+        !ranges.is_empty(),
+        "AST-based folding should detect IF/ELSE without BEGIN"
+    );
+}
+
+#[tokio::test]
+async fn test_folding_range_comment() {
+    let mut service = setup();
+    init_and_open(
+        &mut service,
+        "file:///test.sql",
+        "/* multi-line\n   comment block */\nSELECT 1",
+    )
+    .await;
+
+    let req = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/foldingRange",
+        "params": {
+            "textDocument": { "uri": "file:///test.sql" }
+        }
+    });
+    let response = send(&mut service, &req.to_string()).await;
+
+    assert!(response.is_some(), "Should return folding ranges");
+    let result = response.unwrap();
+    let result_val: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&result.result()).unwrap()).unwrap();
+    let ranges = result_val
+        .as_array()
+        .expect("folding ranges should be array");
+    assert!(
+        ranges
+            .iter()
+            .any(|r| r.get("kind").is_some_and(|k| k == "comment")),
+        "Should contain comment fold for block comment"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `folding_ranges_with_analysis()` that walks AST statements for foldable regions
- Detect IF/WHILE/TRY-CATCH/Block/Procedure without requiring BEGIN...END
- Token-based fallback for broken parser spans (span.end = 0)
- Integrate in server.rs, replacing old token-based `folding_ranges()`
- Add 3 integration tests + 5 unit tests for folding

## Test plan
- [x] 5 new folding unit tests (IF/WHILE without BEGIN, nested, comment preservation)
- [x] 3 new integration tests (BEGIN...END, IF without BEGIN, comment)
- [x] 958 total tests pass
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)