### PR TITLE
feat(lsp): add INSERT column list code action

### DIFF
--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -377,6 +377,23 @@ fn try_add_insert_columns_in_stmt(
                 None
             }
         }
+        Statement::TryCatch(try_catch) => {
+            for child in &try_catch.try_block.statements {
+                if let Some(action) =
+                    try_add_insert_columns_in_stmt(child, analysis, cursor_offset, uri)
+                {
+                    return Some(action);
+                }
+            }
+            for child in &try_catch.catch_block.statements {
+                if let Some(action) =
+                    try_add_insert_columns_in_stmt(child, analysis, cursor_offset, uri)
+                {
+                    return Some(action);
+                }
+            }
+            None
+        }
         _ => None,
     }
 }

--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -320,23 +320,26 @@ fn try_add_insert_columns_in_stmt(
 
             // VALUESトークンの開始位置を見つける
             let values_start = find_values_token_start(&analysis.tokens, insert.span.start)?;
-            let table_start_offset = insert.table.span.start;
-            let t_start = analysis.line_index.offset_to_position(table_start_offset);
+
+            // Insert column list between table name end and VALUES start
+            // Range covers from after table name to before VALUES keyword
+            let table_end = insert.table.span.end;
+            let t_end = analysis.line_index.offset_to_position(table_end);
             let v_start = analysis.line_index.offset_to_position(values_start);
 
             let edit = make_text_edit(
                 uri,
                 Range {
                     start: Position {
-                        line: t_start.0,
-                        character: t_start.1,
+                        line: t_end.0,
+                        character: t_end.1,
                     },
                     end: Position {
                         line: v_start.0,
                         character: v_start.1,
                     },
                 },
-                format!("{table_name} ({col_list}) VALUES"),
+                format!(" ({col_list}) "),
             );
 
             Some(CodeAction {
@@ -383,12 +386,9 @@ fn resolve_stmt_end(span: &tsql_token::Span, tokens: &[crate::analysis::OwnedTok
     if span.end > span.start {
         return span.end;
     }
-    let mut found = false;
-    for tok in tokens {
-        if tok.span.start == span.start {
-            found = true;
-        }
-        if found && tok.kind == TokenKind::Semicolon {
+    let start_idx = tokens.partition_point(|t| t.span.end <= span.start);
+    for tok in &tokens[start_idx..] {
+        if tok.kind == TokenKind::Semicolon {
             return tok.span.end;
         }
     }
@@ -403,12 +403,9 @@ fn find_values_token_start(
     tokens: &[crate::analysis::OwnedToken],
     insert_start: u32,
 ) -> Option<u32> {
-    let mut found = false;
-    for tok in tokens {
-        if tok.span.start == insert_start && tok.kind == TokenKind::Insert {
-            found = true;
-        }
-        if found && tok.kind == TokenKind::Values {
+    let start_idx = tokens.partition_point(|t| t.span.end <= insert_start);
+    for tok in &tokens[start_idx..] {
+        if tok.kind == TokenKind::Values {
             return Some(tok.span.start);
         }
     }
@@ -742,13 +739,14 @@ mod tests {
             let changes = edit.changes.as_ref().unwrap();
             let text_edit = changes.get(&test_uri()).unwrap().first().unwrap();
             assert!(
-                text_edit.new_text.contains("(id, name)"),
+                text_edit.new_text.contains("id, name"),
                 "new_text: {}",
                 text_edit.new_text
             );
+            // new_text inserts column list between table name and VALUES, not including VALUES
             assert!(
-                text_edit.new_text.contains("VALUES"),
-                "Should preserve VALUES"
+                !text_edit.new_text.contains("VALUES"),
+                "new_text should not duplicate VALUES keyword"
             );
         }
     }
@@ -858,12 +856,10 @@ mod tests {
             let changes = edit.changes.as_ref().unwrap();
             let text_edit = changes.get(&test_uri()).unwrap().first().unwrap();
             let new = &text_edit.new_text;
-            // new_text replaces from table name start to VALUES start
+            // new_text inserts column list between table name end and VALUES start
             assert!(new.contains("a, b, c"), "Should contain column list");
-            assert!(new.contains("VALUES"), "Should contain VALUES keyword");
-            // When applied: "t VALUES (1,2,3)" → "t (a, b, c) VALUES (1,2,3)"
-            // Range covers only table name through VALUES keyword
-            assert!(new.starts_with("t"));
+            // VALUES is NOT in new_text — it stays in the document at its original position
+            assert!(!new.contains("VALUES"), "Should not duplicate VALUES");
         }
     }
 }

--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -11,6 +11,8 @@ use lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, WorkspaceEdit,
 };
 use std::collections::HashMap;
+use tsql_parser::ast::Statement;
+use tsql_token::TokenKind;
 
 /// Code Actionsを生成する（DocumentAnalysis利用）
 pub fn code_actions_with_analysis(
@@ -32,6 +34,11 @@ pub fn code_actions_with_analysis(
     }
 
     if let Some(action) = try_generate_insert_skeleton(symbol_table, &line_text, range.start, uri) {
+        actions.push(CodeActionOrCommand::CodeAction(action));
+    }
+
+    // INSERT INTO table VALUES (...) → add column list
+    if let Some(action) = try_add_insert_column_list_ast(analysis, range.start, uri) {
         actions.push(CodeActionOrCommand::CodeAction(action));
     }
 
@@ -244,6 +251,168 @@ fn try_generate_insert_skeleton(
         disabled: None,
         data: None,
     })
+}
+
+/// INSERT INTO table VALUES (...) → カラムリスト追加
+///
+/// ASTのInsertStatementでcolumnsが空、sourceがValuesの場合、
+/// シンボルテーブルからカラムリストを生成して挿入する。
+fn try_add_insert_column_list_ast(
+    analysis: &DocumentAnalysis,
+    position: Position,
+    uri: &lsp_types::Url,
+) -> Option<CodeAction> {
+    let cursor_offset = analysis
+        .line_index
+        .position_to_offset(&analysis.source, position);
+
+    for stmt in &analysis.statements {
+        if let Some(action) = try_add_insert_columns_in_stmt(stmt, analysis, cursor_offset, uri) {
+            return Some(action);
+        }
+    }
+    None
+}
+
+fn try_add_insert_columns_in_stmt(
+    stmt: &Statement,
+    analysis: &DocumentAnalysis,
+    cursor_offset: usize,
+    uri: &lsp_types::Url,
+) -> Option<CodeAction> {
+    match stmt {
+        Statement::Insert(insert) => {
+            // カーソルがINSERTのスパン内にあるか
+            let span_end = resolve_stmt_end(&insert.span, &analysis.tokens);
+            let start = insert.span.start as usize;
+            if cursor_offset < start || cursor_offset > span_end as usize {
+                return None;
+            }
+
+            // 既にカラムリストがある場合はスキップ
+            if !insert.columns.is_empty() {
+                return None;
+            }
+
+            // VALUES句がある場合のみ対象
+            if !matches!(&insert.source, tsql_parser::ast::InsertSource::Values(_)) {
+                return None;
+            }
+
+            let table_name = &insert.table.name;
+            let tbl = SymbolTableBuilder::find_table(&analysis.symbol_table, table_name)?;
+            if tbl.columns.is_empty() {
+                return None;
+            }
+
+            // IDENTITYカラムは除外
+            let columns: Vec<&str> = tbl
+                .columns
+                .iter()
+                .filter(|c| !c.is_identity)
+                .map(|c| c.name.as_str())
+                .collect();
+            if columns.is_empty() {
+                return None;
+            }
+
+            let col_list = columns.join(", ");
+
+            // VALUESトークンの開始位置を見つける
+            let values_start = find_values_token_start(&analysis.tokens, insert.span.start)?;
+            let table_start_offset = insert.table.span.start;
+            let t_start = analysis.line_index.offset_to_position(table_start_offset);
+            let v_start = analysis.line_index.offset_to_position(values_start);
+
+            let edit = make_text_edit(
+                uri,
+                Range {
+                    start: Position {
+                        line: t_start.0,
+                        character: t_start.1,
+                    },
+                    end: Position {
+                        line: v_start.0,
+                        character: v_start.1,
+                    },
+                },
+                format!("{table_name} ({col_list}) VALUES"),
+            );
+
+            Some(CodeAction {
+                title: format!("Add column list to INSERT for {table_name}"),
+                kind: Some(CodeActionKind::QUICKFIX),
+                diagnostics: None,
+                edit: Some(edit),
+                command: None,
+                is_preferred: Some(true),
+                disabled: None,
+                data: None,
+            })
+        }
+        Statement::Block(block) => block
+            .statements
+            .iter()
+            .find_map(|child| try_add_insert_columns_in_stmt(child, analysis, cursor_offset, uri)),
+        Statement::If(if_stmt) => {
+            try_add_insert_columns_in_stmt(&if_stmt.then_branch, analysis, cursor_offset, uri)
+                .or_else(|| {
+                    if_stmt.else_branch.as_ref().and_then(|else_b| {
+                        try_add_insert_columns_in_stmt(else_b, analysis, cursor_offset, uri)
+                    })
+                })
+        }
+        Statement::While(while_stmt) => {
+            try_add_insert_columns_in_stmt(&while_stmt.body, analysis, cursor_offset, uri)
+        }
+        Statement::Create(create) => {
+            if let tsql_parser::ast::CreateStatement::Procedure(proc) = &**create {
+                proc.body.iter().find_map(|child| {
+                    try_add_insert_columns_in_stmt(child, analysis, cursor_offset, uri)
+                })
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// INSERTスパンの終了位置を解決
+fn resolve_stmt_end(span: &tsql_token::Span, tokens: &[crate::analysis::OwnedToken]) -> u32 {
+    if span.end > span.start {
+        return span.end;
+    }
+    let mut found = false;
+    for tok in tokens {
+        if tok.span.start == span.start {
+            found = true;
+        }
+        if found && tok.kind == TokenKind::Semicolon {
+            return tok.span.end;
+        }
+    }
+    tokens
+        .last()
+        .map(|t| t.span.end)
+        .unwrap_or(span.start + 100)
+}
+
+/// VALUESトークンの開始位置を見つける
+fn find_values_token_start(
+    tokens: &[crate::analysis::OwnedToken],
+    insert_start: u32,
+) -> Option<u32> {
+    let mut found = false;
+    for tok in tokens {
+        if tok.span.start == insert_start && tok.kind == TokenKind::Insert {
+            found = true;
+        }
+        if found && tok.kind == TokenKind::Values {
+            return Some(tok.span.start);
+        }
+    }
+    None
 }
 
 /// BEGIN → TRY...CATCH ラッパー
@@ -544,5 +713,157 @@ mod tests {
             matches!(a, CodeActionOrCommand::CodeAction(ca) if ca.title.contains("INSERT skeleton"))
         });
         assert!(insert_action.is_none());
+    }
+
+    // === INSERT column list code action ===
+
+    #[test]
+    fn test_insert_add_column_list() {
+        // INSERT INTO t VALUES (1, 'test') → INSERT INTO t (id, name) VALUES (1, 'test')
+        let source = "CREATE TABLE t (id INT, name VARCHAR(100))\nINSERT INTO t VALUES (1, 'test')";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let range = Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 20,
+            },
+        };
+        let actions = code_actions_with_analysis(&analysis, range, &test_uri());
+        let add_cols = actions.iter().find(|a| {
+            matches!(a, CodeActionOrCommand::CodeAction(ca) if ca.title.contains("Add column list"))
+        });
+        assert!(add_cols.is_some(), "Should offer to add column list");
+        if let CodeActionOrCommand::CodeAction(ca) = add_cols.unwrap() {
+            let edit = ca.edit.as_ref().unwrap();
+            let changes = edit.changes.as_ref().unwrap();
+            let text_edit = changes.get(&test_uri()).unwrap().first().unwrap();
+            assert!(
+                text_edit.new_text.contains("(id, name)"),
+                "new_text: {}",
+                text_edit.new_text
+            );
+            assert!(
+                text_edit.new_text.contains("VALUES"),
+                "Should preserve VALUES"
+            );
+        }
+    }
+
+    #[test]
+    fn test_insert_skip_when_columns_exist() {
+        // Already has column list → skip
+        let source = "CREATE TABLE t (id INT, name VARCHAR(100))\nINSERT INTO t (id, name) VALUES (1, 'test')";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let range = Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 20,
+            },
+        };
+        let actions = code_actions_with_analysis(&analysis, range, &test_uri());
+        let add_cols = actions.iter().find(|a| {
+            matches!(a, CodeActionOrCommand::CodeAction(ca) if ca.title.contains("Add column list"))
+        });
+        assert!(
+            add_cols.is_none(),
+            "Should not offer when columns already listed"
+        );
+    }
+
+    #[test]
+    fn test_insert_column_list_skips_identity() {
+        // IDENTITY column excluded from list
+        let source =
+            "CREATE TABLE t (id INT IDENTITY, name VARCHAR(100))\nINSERT INTO t VALUES ('test')";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let range = Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 20,
+            },
+        };
+        let actions = code_actions_with_analysis(&analysis, range, &test_uri());
+        let add_cols = actions.iter().find(|a| {
+            matches!(a, CodeActionOrCommand::CodeAction(ca) if ca.title.contains("Add column list"))
+        });
+        assert!(add_cols.is_some());
+        if let CodeActionOrCommand::CodeAction(ca) = add_cols.unwrap() {
+            let edit = ca.edit.as_ref().unwrap();
+            let changes = edit.changes.as_ref().unwrap();
+            let text_edit = changes.get(&test_uri()).unwrap().first().unwrap();
+            assert!(
+                !text_edit.new_text.contains("id"),
+                "IDENTITY should be excluded"
+            );
+            assert!(text_edit.new_text.contains("name"));
+        }
+    }
+
+    #[test]
+    fn test_insert_column_list_unknown_table_skip() {
+        // Unknown table → skip
+        let source = "INSERT INTO unknown VALUES (1)";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 10,
+            },
+        };
+        let actions = code_actions_with_analysis(&analysis, range, &test_uri());
+        let add_cols = actions.iter().find(|a| {
+            matches!(a, CodeActionOrCommand::CodeAction(ca) if ca.title.contains("Add column list"))
+        });
+        assert!(add_cols.is_none());
+    }
+
+    #[test]
+    fn test_insert_column_list_preserves_values() {
+        // new_text replaces table name through VALUES keyword, column list inserted
+        let source = "CREATE TABLE t (a INT, b INT, c INT)\nINSERT INTO t VALUES (1, 2, 3)";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let range = Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 20,
+            },
+        };
+        let actions = code_actions_with_analysis(&analysis, range, &test_uri());
+        let add_cols = actions.iter().find(|a| {
+            matches!(a, CodeActionOrCommand::CodeAction(ca) if ca.title.contains("Add column list"))
+        });
+        assert!(add_cols.is_some());
+        if let CodeActionOrCommand::CodeAction(ca) = add_cols.unwrap() {
+            let edit = ca.edit.as_ref().unwrap();
+            let changes = edit.changes.as_ref().unwrap();
+            let text_edit = changes.get(&test_uri()).unwrap().first().unwrap();
+            let new = &text_edit.new_text;
+            // new_text replaces from table name start to VALUES start
+            assert!(new.contains("a, b, c"), "Should contain column list");
+            assert!(new.contains("VALUES"), "Should contain VALUES keyword");
+            // When applied: "t VALUES (1,2,3)" → "t (a, b, c) VALUES (1,2,3)"
+            // Range covers only table name through VALUES keyword
+            assert!(new.starts_with("t"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- INSERT column list code action: adds column list (excluding IDENTITY) for `INSERT INTO t VALUES (...)`
- Fixes text edit range bug that caused duplicate VALUES keyword
- Uses `partition_point` binary search for O(log n) token lookup

## Type of Change
- [x] feat: New code action

## Testing
- Existing tests pass (955)
- Verified: no duplicate VALUES after applying edit
- fmt/clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)