### PR TITLE
feat(parser): add EXEC/EXECUTE statement support

### DIFF
--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -2,7 +2,7 @@
 
 > **各エージェントへ**: 作業前に必ずこのファイルを読むこと。
 
-**最終更新:** 2026-05-30 / Session (Issue triage & PR consolidation)
+**最終更新:** 2026-05-31 / Session (EXEC parser #115)
 
 ---
 
@@ -10,11 +10,11 @@
 
 | 項目 | 状態 |
 |------|------|
-| **テスト** | 942 passed, 2 skipped |
+| **テスト** | 988 passed, 2 skipped |
 | **Clippy** | clean (`-D warnings`) |
-| **Open Issues** | 20 (内6件は今セッションで作成したサブIssue) |
-| **Open PRs** | 1 (#106 INSERT column list — rebase必要) |
-| **ブランチ** | master + feat/code-action-insert-column-list のみ |
+| **Open Issues** | 19 |
+| **Open PRs** | 2 (#106, #121) |
+| **ブランチ** | master + feat/code-action-insert-column-list + feat/115-exec-execute-parser |
 
 ---
 
@@ -46,8 +46,9 @@
 ## 🔀 申し送り（次セッションへ）
 
 ### 優先度高
-1. **PR #106** (INSERT column list): masterにリベースが必要。CI未完了。マージ後にconflict解消。
-2. **#114 ALTER TABLE parser**: ASE開発で頻出。中規模タスク。
+1. **PR #121** (EXEC parser): レビュー待ち。マージ後 #115 Close。
+2. **PR #106** (INSERT column list): masterにリベースが必要。CI未完了。マージ後にconflict解消。
+3. **#116 CREATE TRIGGER parser**: #58サブIssueの残り。
 
 ### 優先度中
 3. **#71 db_docs.rs**: 1305行モノリス。データとロジックの分離。

--- a/crates/ase-ls-core/src/folding.rs
+++ b/crates/ase-ls-core/src/folding.rs
@@ -110,6 +110,7 @@ fn collect_ast_folds(
         | Statement::Throw(_)
         | Statement::Raiserror(_)
         | Statement::AlterTable(_)
+        | Statement::Exec(_)
         | Statement::BatchSeparator(_) => {}
     }
 }

--- a/crates/ase-ls-core/src/symbol_table/mod.rs
+++ b/crates/ase-ls-core/src/symbol_table/mod.rs
@@ -349,6 +349,7 @@ impl SymbolTableBuilder {
             | Statement::Throw(_)
             | Statement::Raiserror(_)
             | Statement::AlterTable(_)
+            | Statement::Exec(_)
             | Statement::BatchSeparator(_) => {}
         }
     }
@@ -425,6 +426,7 @@ impl SymbolTableBuilder {
             | Statement::Transaction(_)
             | Statement::Throw(_)
             | Statement::Raiserror(_)
+            | Statement::Exec(_)
             | Statement::BatchSeparator(_) => {}
         }
     }

--- a/crates/tsql-parser/src/ast/ddl.rs
+++ b/crates/tsql-parser/src/ast/ddl.rs
@@ -295,3 +295,34 @@ pub struct AlterColumnDefinition {
     /// NULL許容
     pub nullability: Option<bool>,
 }
+
+/// EXEC/EXECUTE文（プロシージャ呼び出し）
+#[derive(Debug, Clone)]
+pub struct ExecStatement {
+    /// 位置情報
+    pub span: Span,
+    /// プロシージャ名
+    pub procedure: Identifier,
+    /// パラメータ引数リスト
+    pub arguments: Vec<ExecArgument>,
+}
+
+impl AstNode for ExecStatement {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+/// EXEC引数（位置パラメータまたは名前付きパラメータ）
+#[derive(Debug, Clone)]
+pub enum ExecArgument {
+    /// 位置パラメータ: EXEC proc value1, value2
+    Positional(Expression),
+    /// 名前付きパラメータ: EXEC proc @param1 = value1
+    Named {
+        /// パラメータ名（@で始まる）
+        name: Identifier,
+        /// パラメータ値
+        value: Expression,
+    },
+}

--- a/crates/tsql-parser/src/ast/mod.rs
+++ b/crates/tsql-parser/src/ast/mod.rs
@@ -29,8 +29,9 @@ pub use data_modification::{
 };
 pub use ddl::{
     AddColumnDefinition, AlterColumnDefinition, AlterTableOperation, AlterTableStatement,
-    ColumnConstraint, ColumnDefinition, CreateStatement, DataType, IndexDefinition,
-    ParameterDefinition, ProcedureDefinition, TableConstraint, TableDefinition, ViewDefinition,
+    ColumnConstraint, ColumnDefinition, CreateStatement, DataType, ExecArgument, ExecStatement,
+    IndexDefinition, ParameterDefinition, ProcedureDefinition, TableConstraint, TableDefinition,
+    ViewDefinition,
 };
 pub use select::{
     FromClause, Join, JoinType, LimitClause, OrderByItem, SelectItem, SelectStatement,
@@ -89,6 +90,8 @@ pub enum Statement {
     Throw(Box<ThrowStatement>),
     /// RAISERROR 文
     Raiserror(Box<RaiserrorStatement>),
+    /// EXEC/EXECUTE 文（プロシージャ呼び出し）
+    Exec(Box<ExecStatement>),
     /// バッチ区切り（GO）
     BatchSeparator(BatchSeparator),
 }
@@ -115,6 +118,7 @@ impl AstNode for Statement {
             Statement::Transaction(s) => s.span(),
             Statement::Throw(s) => s.span,
             Statement::Raiserror(s) => s.span,
+            Statement::Exec(s) => s.span,
             Statement::BatchSeparator(s) => s.span,
         }
     }

--- a/crates/tsql-parser/src/ast/to_common.rs
+++ b/crates/tsql-parser/src/ast/to_common.rs
@@ -40,6 +40,11 @@ impl ToCommonAst for Statement {
                 description: format!("ALTER TABLE statement: {:?}", self),
                 span: self.span(),
             }),
+            // EXEC/EXECUTE文も方言固有
+            Statement::Exec(_) => Some(CommonStatement::DialectSpecific {
+                description: format!("EXEC statement: {:?}", self),
+                span: self.span(),
+            }),
             // 変数代入文も方言固有
             Statement::VariableAssignment(_) => Some(CommonStatement::DialectSpecific {
                 description: format!("Variable assignment: {:?}", self),

--- a/crates/tsql-parser/src/parser.rs
+++ b/crates/tsql-parser/src/parser.rs
@@ -202,6 +202,8 @@ impl<'src> Parser<'src> {
             TokenKind::Throw => self.parse_throw_statement(),
             // RAISERROR 文
             TokenKind::Raiserror => self.parse_raiserror_statement(),
+            // EXEC/EXECUTE 文
+            TokenKind::Exec | TokenKind::Execute => self.parse_exec_statement(),
             // GOバッチ区切り（BatchModeのみ）
             TokenKind::Go => {
                 if matches!(self.mode, ParserMode::BatchMode) {
@@ -2439,6 +2441,90 @@ impl<'src> Parser<'src> {
             message,
             severity,
             state,
+        })))
+    }
+
+    /// EXEC/EXECUTE文を解析
+    fn parse_exec_statement(&mut self) -> ParseResult<Statement> {
+        let start = self.buffer.current()?.span.start;
+        self.buffer.consume()?; // EXEC or EXECUTE
+
+        let procedure = self.parse_identifier()?;
+
+        let mut arguments = Vec::new();
+
+        // Parse arguments: first arg has no comma, subsequent args require comma
+        // Supports: EXEC proc value1, @p1 = val, @p2
+        let mut first_arg = true;
+        loop {
+            if !first_arg {
+                // Subsequent arguments must be preceded by comma
+                if !self.buffer.check(TokenKind::Comma) {
+                    break;
+                }
+                self.buffer.consume()?; // consume comma
+            }
+            first_arg = false;
+
+            // Check if this is a named parameter: @param = value
+            if self.buffer.check(TokenKind::LocalVar) {
+                let param_name = self.parse_identifier()?;
+                if self.buffer.check(TokenKind::Eq) || self.buffer.check(TokenKind::Assign) {
+                    self.buffer.consume()?; // =
+                    let mut expr_parser = ExpressionParser::new(&mut self.buffer);
+                    let value = expr_parser.parse()?;
+                    arguments.push(ExecArgument::Named {
+                        name: param_name,
+                        value,
+                    });
+                } else {
+                    // Variable without assignment — treat as positional
+                    arguments.push(ExecArgument::Positional(Expression::Identifier(param_name)));
+                }
+            } else {
+                // Try to parse a positional expression; if we can't, we're done
+                let mut expr_parser = ExpressionParser::new(&mut self.buffer);
+                match expr_parser.parse() {
+                    Ok(value) => arguments.push(ExecArgument::Positional(value)),
+                    Err(_) => break,
+                }
+            }
+        }
+
+        // Compute span end from the last meaningful token
+        let end = if let Some(last_arg) = arguments.last() {
+            match last_arg {
+                ExecArgument::Positional(expr) => {
+                    let s = expr.span();
+                    if s.end > 0 {
+                        s.end
+                    } else {
+                        s.start
+                    }
+                }
+                ExecArgument::Named { value, .. } => {
+                    let s = value.span();
+                    if s.end > 0 {
+                        s.end
+                    } else {
+                        s.start
+                    }
+                }
+            }
+        } else {
+            // No arguments — span ends at procedure name
+            let s = procedure.span;
+            if s.end > 0 {
+                s.end
+            } else {
+                s.start
+            }
+        };
+
+        Ok(Statement::Exec(Box::new(ExecStatement {
+            span: Span { start, end },
+            procedure,
+            arguments,
         })))
     }
 
@@ -5059,6 +5145,297 @@ mod tests {
                 assert_eq!(alter.table.name, "users");
             }
             _ => panic!("Expected AlterTable"),
+        }
+    }
+
+    // === EXEC / EXECUTE tests ===
+
+    #[test]
+    fn test_exec_no_args() {
+        // EXEC proc_name — 引数なし
+        let result = parse_sql("EXEC my_proc").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert!(exec.arguments.is_empty());
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_execute_keyword() {
+        // EXECUTE proc_name — EXECUTE キーワード
+        let result = parse_sql("EXECUTE my_proc").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert!(exec.arguments.is_empty());
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_positional_args() {
+        // EXEC proc_name 1, 2, 3 — 位置パラメータ
+        let result = parse_sql("EXEC my_proc 1, 2, 3").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert_eq!(exec.arguments.len(), 3);
+                // All arguments should be positional
+                for arg in &exec.arguments {
+                    assert!(
+                        matches!(arg, ExecArgument::Positional(_)),
+                        "Expected Positional argument"
+                    );
+                }
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_named_param() {
+        // EXEC proc_name @p1 = 1 — 名前付きパラメータ
+        let result = parse_sql("EXEC my_proc @p1 = 1").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert_eq!(exec.arguments.len(), 1);
+                match &exec.arguments[0] {
+                    ExecArgument::Named { name, value } => {
+                        assert_eq!(name.name, "@p1");
+                        assert!(
+                            matches!(value, Expression::Literal(Literal::Number(_, _))),
+                            "Expected Number literal for named param value"
+                        );
+                    }
+                    _ => panic!("Expected Named argument"),
+                }
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_multiple_named_params() {
+        // EXEC proc_name @p1 = 1, @p2 = 2 — 複数名前付きパラメータ
+        let result = parse_sql("EXEC my_proc @p1 = 1, @p2 = 2").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert_eq!(exec.arguments.len(), 2);
+                match &exec.arguments[0] {
+                    ExecArgument::Named { name, .. } => {
+                        assert_eq!(name.name, "@p1");
+                    }
+                    _ => panic!("Expected Named argument for @p1"),
+                }
+                match &exec.arguments[1] {
+                    ExecArgument::Named { name, .. } => {
+                        assert_eq!(name.name, "@p2");
+                    }
+                    _ => panic!("Expected Named argument for @p2"),
+                }
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_string_literal_arg() {
+        // EXEC proc_name 'hello' — 文字列リテラル引数
+        let result = parse_sql("EXEC my_proc 'hello'").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert_eq!(exec.arguments.len(), 1);
+                match &exec.arguments[0] {
+                    ExecArgument::Positional(expr) => {
+                        assert!(
+                            matches!(expr, Expression::Literal(Literal::String(_, _))),
+                            "Expected String literal argument"
+                        );
+                    }
+                    _ => panic!("Expected Positional argument"),
+                }
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_mixed_named_and_positional_args() {
+        // EXEC proc_name @p1 = 1, 'hello' — 名前付きと位置の混在
+        let result = parse_sql("EXEC my_proc @p1 = 1, 'hello'").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert_eq!(exec.arguments.len(), 2);
+                // First argument: named
+                assert!(
+                    matches!(&exec.arguments[0], ExecArgument::Named { name, .. } if name.name == "@p1"),
+                    "Expected Named(@p1) as first argument"
+                );
+                // Second argument: positional string literal
+                assert!(
+                    matches!(
+                        &exec.arguments[1],
+                        ExecArgument::Positional(Expression::Literal(Literal::String(_, _)))
+                    ),
+                    "Expected Positional(String) as second argument"
+                );
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_variable_positional_arg() {
+        // EXEC proc_name @var — 変数のみ（代入なし）の位置引数
+        let result = parse_sql("EXEC my_proc @var").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert_eq!(exec.arguments.len(), 1);
+                match &exec.arguments[0] {
+                    ExecArgument::Positional(expr) => {
+                        assert!(
+                            matches!(expr, Expression::Identifier(id) if id.name == "@var"),
+                            "Expected Identifier(@var) as positional argument"
+                        );
+                    }
+                    _ => panic!("Expected Positional argument"),
+                }
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_with_semicolon() {
+        // EXEC proc_name; の後にセミコロン → セミコロンは引数として扱われない
+        let result = parse_sql("EXEC my_proc;").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert!(
+                    exec.arguments.is_empty(),
+                    "Semicolon should not be treated as an argument"
+                );
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_null_arg() {
+        // EXEC proc_name NULL — NULL引数
+        let result = parse_sql("EXEC my_proc NULL").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert_eq!(exec.arguments.len(), 1);
+                match &exec.arguments[0] {
+                    ExecArgument::Positional(expr) => {
+                        assert!(
+                            matches!(expr, Expression::Literal(Literal::Null(_))),
+                            "Expected Null literal argument"
+                        );
+                    }
+                    _ => panic!("Expected Positional argument"),
+                }
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_missing_procedure_name() {
+        // EXEC の後にプロシージャ名がない → エラー
+        let result = parse_sql("EXEC");
+        assert!(
+            result.is_err(),
+            "EXEC without procedure name should be a parse error"
+        );
+    }
+
+    #[test]
+    fn test_exec_followed_by_next_statement() {
+        // EXEC文の後に別の文が続く場合
+        let result = parse_sql("EXEC my_proc 1\nSELECT 1").unwrap();
+        assert_eq!(result.len(), 2);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert_eq!(exec.arguments.len(), 1);
+            }
+            _ => panic!("Expected Exec as first statement"),
+        }
+        match &result[1] {
+            Statement::Select(_) => {}
+            _ => panic!("Expected Select as second statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_named_params_mixed_with_positional() {
+        // EXEC proc_name 'hello', @p2 = 2, 3 — 位置、名前付き、位置の混在
+        let result = parse_sql("EXEC my_proc 'hello', @p2 = 2, 3").unwrap();
+        assert_eq!(result.len(), 1);
+        match &result[0] {
+            Statement::Exec(exec) => {
+                assert_eq!(exec.procedure.name, "my_proc");
+                assert_eq!(exec.arguments.len(), 3);
+                // First: positional string
+                assert!(
+                    matches!(
+                        &exec.arguments[0],
+                        ExecArgument::Positional(Expression::Literal(Literal::String(_, _)))
+                    ),
+                    "First arg should be Positional(String)"
+                );
+                // Second: named
+                assert!(
+                    matches!(&exec.arguments[1], ExecArgument::Named { name, .. } if name.name == "@p2"),
+                    "Second arg should be Named(@p2)"
+                );
+                // Third: positional number
+                assert!(
+                    matches!(
+                        &exec.arguments[2],
+                        ExecArgument::Positional(Expression::Literal(Literal::Number(_, _)))
+                    ),
+                    "Third arg should be Positional(Number)"
+                );
+            }
+            _ => panic!("Expected Exec statement"),
+        }
+    }
+
+    #[test]
+    fn test_exec_span_includes_procedure_and_args() {
+        // EXEC文のspanがプロシージャ名と引数を含む
+        let result = parse_sql("EXEC my_proc 1, 2").unwrap();
+        match &result[0] {
+            Statement::Exec(exec) => {
+                // span should start at the beginning of EXEC
+                assert!(exec.span.start < exec.span.end, "Span should be non-empty");
+                assert_ne!(exec.span.end, 0, "Span end should not be zero");
+            }
+            _ => panic!("Expected Exec statement"),
         }
     }
 }

--- a/crates/wasm/src/ast_js.rs
+++ b/crates/wasm/src/ast_js.rs
@@ -125,6 +125,10 @@ pub enum JsStatement {
     Throw,
     /// RAISERROR statement
     Raiserror,
+    /// EXEC/EXECUTE statement
+    Exec,
+    /// ALTER TABLE statement
+    AlterTable,
 }
 
 #[cfg(feature = "wasm")]
@@ -172,6 +176,8 @@ impl TryFrom<Statement> for JsStatement {
             Statement::Transaction(_) => Ok(Self::Transaction),
             Statement::Throw(_) => Ok(Self::Throw),
             Statement::Raiserror(_) => Ok(Self::Raiserror),
+            Statement::Exec(_) => Ok(Self::Exec),
+            Statement::AlterTable(_) => Ok(Self::AlterTable),
         }
     }
 }


### PR DESCRIPTION
## 概要

EXEC/EXECUTE プロシージャ呼び出し文のパーサーサポートを追加。

Closes #115

## 変更内容

### 新規AST型 (`ddl.rs`)
- `ExecStatement`: プロシージャ名 + 引数リスト
- `ExecArgument`: 位置パラメータ or 名前付きパラメータ (`@param = value`)

### パーサー実装 (`parser.rs`)
- `parse_exec_statement()`: EXEC/EXECUTE 両キーワード対応
- 引数なし / 位置引数 / 名前付き引数 / 混在 に対応
- `LocalVar` 単独（`@var`）の位置引数に対応

### 影響範囲
- `Statement::Exec` variant 追加に伴う match exhaustive 更新:
  - `folding.rs`, `symbol_table/mod.rs` (2箇所)
- `to_common.rs`: DialectSpecific として処理

### テスト
14件追加（全てパス）:
- 正常系: no-args, EXECUTE keyword, positional, named, multiple named, string literal, mixed, variable-only
- エッジケース: semicolon, NULL arg, missing procedure name, next statement, span verification

## 品質チェック
- [x] `cargo fmt --all --check` ✅
- [x] `cargo clippy --all-targets -- -D warnings` ✅
- [x] `cargo nextest run --workspace` — 988 passed, 2 skipped ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: glm 4.7 <noreply@zhipuai.cn>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parsing support for T-SQL EXEC/EXECUTE statements, including procedure identifiers and argument handling.
  * Supports both positional arguments and named parameters using `@variable` = value syntax.
  * Integrated EXEC statement analysis into code folding and symbol table features for complete language support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Protom512/tsqlremaker/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->