### PR TITLE
refactor(core): code quality improvements, zero-alloc optimizations, +11 tests

### DIFF
--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -24,18 +24,21 @@
 | コミット | 内容 |
 |---------|------|
 | `cec4854` | refactor(core): eliminate Arc<str> clones, dedup semantic tokens, add find_token_at_position |
+| `5c71e83` | perf(hover): use entry.name instead of allocated upper in build_hover_content |
+| `e6938a6` | fix(parser): return ParseError for invalid BINARY length instead of silent default |
 
 ### 変更内容
 - **hover/definition/references/rename**: `Arc<str>.clone()` → `&str` 借用に置換（ホットパスでのアトミック参照カウント操作を回避）
 - **semantic_tokens**: `DeltaEncoder` 構造体を抽出し、`semantic_tokens_full_with_analysis` と `semantic_tokens_range_with_analysis` 間の約30行の重複コードを除去
 - **analysis.rs**: `find_token_at_position(position)` ヘルパーを追加。6ファイルのoffset→token検索ボイラープレートを統一
 - **signature_help**: `scan_for_call_frame` の `pending_name` を `Option<String>` → `Option<&str>` に変更し、CallFrameプッシュ時のみ `.to_uppercase()` を実行（非関数トークンでのアロケーション回避）
+- **hover.rs**: `build_hover_content` で `entry.name` を使用し、エントリ発見時の不要な `upper` 変数使用を回避
 - **symbol_table**: `find_*` 6関数 + `resolve_semantic_type` に `#[inline]` 追加。`build/build_tolerant` に `#[must_use]` 追加
 - **completion**: `build_function_snippet`, `is_comma_separated_syntax` に `#[must_use]` 追加
 - **code_actions**: `find_ignore_ascii_case`, `contains_ignore_ascii_case` に `#[must_use]` 追加
 - **formatting**: `should_newline_before`, `needs_space_before`, `should_decrease_indent` に `#[inline]` 追加
 - **symbol_table**: デッドコード `find_identifier_at` とそのテストを削除（Session 19以降未使用）
-- **-45行** (164行削除、119行追加、11ファイル変更)
+- **parser**: `BINARY(abc)` のような無効な長さ指定がサイレントにデフォルト値1になっていた問題を修正。VARCHAR/DECIMALと同様に `InvalidSyntax` エラーを返すよう変更
 - **1089 tests passed** (-1 from find_identifier_at test removal)
 
 ## 🔄 Session 23 成果

--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -26,6 +26,7 @@
 | `1c09cf3` | perf(server): wrap DocumentAnalysis in Arc to avoid clone-on-read |
 | `8267468` | refactor: add const fn to 29 pure functions across 4 crates |
 | `7114367` | perf(core): add #[inline] to hot-path LineIndex and DocumentAnalysis accessors |
+| `3c9ec2b` | perf(core): change OwnedToken.text from String to Arc<str> |
 
 ### 変更内容
 - **server.rs**: `DocumentStore`が`Arc<DocumentAnalysis>`を格納。`get_analysis()`が`Option<Arc<DocumentAnalysis>>`を返す。Deref coercionで呼び出し元は`&DocumentAnalysis`を透過的に取得
@@ -39,6 +40,7 @@
 - `Arc<DocumentAnalysis>`: リクエストごとのclone（~50KB DocumentAnalysis）を`Arc::clone`（8バイトポインタコピー）に削減
 - `const fn` 29箇所: コンパイラの最適化ヒント + 純粋性の型レベル表明
 - `#[inline]` 7箇所: ホットパスの関数呼び出しオーバーヘッドを除去
+- `Arc<str>` for OwnedToken.text: 4ハンドラの`.clone()`がO(n)→O(1)に
 
 ## ✅ コード品質改善 完了状況
 

--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -26,6 +26,7 @@
 | `cec4854` | refactor(core): eliminate Arc<str> clones, dedup semantic tokens, add find_token_at_position |
 | `5c71e83` | perf(hover): use entry.name instead of allocated upper in build_hover_content |
 | `e6938a6` | fix(parser): return ParseError for invalid BINARY length instead of silent default |
+| `e91b0d2` | refactor(parser): add #[must_use] to public parse functions and with_mode |
 
 ### 変更内容
 - **hover/definition/references/rename**: `Arc<str>.clone()` → `&str` 借用に置換（ホットパスでのアトミック参照カウント操作を回避）
@@ -39,6 +40,7 @@
 - **formatting**: `should_newline_before`, `needs_space_before`, `should_decrease_indent` に `#[inline]` 追加
 - **symbol_table**: デッドコード `find_identifier_at` とそのテストを削除（Session 19以降未使用）
 - **parser**: `BINARY(abc)` のような無効な長さ指定がサイレントにデフォルト値1になっていた問題を修正。VARCHAR/DECIMALと同様に `InvalidSyntax` エラーを返すよう変更
+- **parser**: `parse`, `parse_one`, `parse_with_errors`, `with_mode` に `#[must_use]` 追加
 - **1089 tests passed** (-1 from find_identifier_at test removal)
 
 ## 🔄 Session 23 成果

--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -2,7 +2,7 @@
 
 > **各エージェントへ**: 作業前に必ずこのファイルを読むこと。
 
-**最終更新:** 2026-06-06 / Session 22 final (all code quality tasks completed)
+**最終更新:** 2026-06-06 / Session 23 (Arc + const fn + inline optimizations)
 
 ---
 
@@ -17,6 +17,28 @@
 | **Open Issues** | 12 (全てLarge機能、コード品質改善なし) |
 | **Open PRs** | 2 (#123 INSERT column list, #124 code quality) |
 | **ブランチ** | master + feat/insert-column-list-v2 (#123) + refactor/session-21-code-quality (#124) |
+
+## 🔄 Session 23 成果
+
+### コミット（PR #124 ブランチ）
+| コミット | 内容 |
+|---------|------|
+| `1c09cf3` | perf(server): wrap DocumentAnalysis in Arc to avoid clone-on-read |
+| `8267468` | refactor: add const fn to 29 pure functions across 4 crates |
+| `7114367` | perf(core): add #[inline] to hot-path LineIndex and DocumentAnalysis accessors |
+
+### 変更内容
+- **server.rs**: `DocumentStore`が`Arc<DocumentAnalysis>`を格納。`get_analysis()`が`Option<Arc<DocumentAnalysis>>`を返す。Deref coercionで呼び出し元は`&DocumentAnalysis`を透過的に取得
+- **tsql-lexer** (5箇所): `is_eof`, `set_tab_width`, `position`, `with_comments`, `has_errors` → `const fn`
+- **tsql-parser** (15箇所): `Literal::span`, `position_at_eof`, `ParseError::unexpected_token/unexpected_eof/invalid_syntax/recursion_limit`, `ParseErrors::new/is_empty/len`, `get_infix_binding_power`, `span_for_binary`, `can_keyword_be_identifier`, `with_max_depth`, `with_mode`, `has_errors` → `const fn`
+- **ase-ls-core** (9箇所): `make_quickfix`, `make_refactor`, `should_newline_before`, `needs_space_before`, `should_decrease_indent`, `in_span`, `line_count`, `token_kind_to_type_index`, `make_symbol` → `const fn`
+- **line_index.rs** (5箇所): `offset_to_position`, `position_to_offset`, `line_number`, `line_offset`, `offset_to_range` → `#[inline]`
+- **analysis.rs** (2箇所): `find_token_at`, `get_line` → `#[inline]`
+
+### 削減効果
+- `Arc<DocumentAnalysis>`: リクエストごとのclone（~50KB DocumentAnalysis）を`Arc::clone`（8バイトポインタコピー）に削減
+- `const fn` 29箇所: コンパイラの最適化ヒント + 純粋性の型レベル表明
+- `#[inline]` 7箇所: ホットパスの関数呼び出しオーバーヘッドを除去
 
 ## ✅ コード品質改善 完了状況
 

--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -2,7 +2,7 @@
 
 > **各エージェントへ**: 作業前に必ずこのファイルを読むこと。
 
-**最終更新:** 2026-06-06 / Session 23 (Arc + const fn + inline optimizations)
+**最終更新:** 2026-06-07 / Session 24 (Arc<str> borrow, delta dedup, find_token_at_position)
 
 ---
 
@@ -10,13 +10,33 @@
 
 | 項目 | 状態 |
 |------|------|
-| **テスト** | 1090 passed, 2 skipped (branch refactor/session-21-code-quality) |
+| **テスト** | 1089 passed, 2 skipped (branch refactor/session-21-code-quality) |
 | **Clippy** | clean (`-D warnings`) |
 | **Fmt** | clean |
 | **Coupling** | Grade D (0.39) — emitter→parser依存は構造的、db_docs→DocEntryは同一crate内 |
 | **Open Issues** | 12 (全てLarge機能、コード品質改善なし) |
 | **Open PRs** | 2 (#123 INSERT column list, #124 code quality) |
 | **ブランチ** | master + feat/insert-column-list-v2 (#123) + refactor/session-21-code-quality (#124) |
+
+## 🔄 Session 24 成果
+
+### コミット（PR #124 ブランチ）
+| コミット | 内容 |
+|---------|------|
+| `cec4854` | refactor(core): eliminate Arc<str> clones, dedup semantic tokens, add find_token_at_position |
+
+### 変更内容
+- **hover/definition/references/rename**: `Arc<str>.clone()` → `&str` 借用に置換（ホットパスでのアトミック参照カウント操作を回避）
+- **semantic_tokens**: `DeltaEncoder` 構造体を抽出し、`semantic_tokens_full_with_analysis` と `semantic_tokens_range_with_analysis` 間の約30行の重複コードを除去
+- **analysis.rs**: `find_token_at_position(position)` ヘルパーを追加。6ファイルのoffset→token検索ボイラープレートを統一
+- **signature_help**: `scan_for_call_frame` の `pending_name` を `Option<String>` → `Option<&str>` に変更し、CallFrameプッシュ時のみ `.to_uppercase()` を実行（非関数トークンでのアロケーション回避）
+- **symbol_table**: `find_*` 6関数 + `resolve_semantic_type` に `#[inline]` 追加。`build/build_tolerant` に `#[must_use]` 追加
+- **completion**: `build_function_snippet`, `is_comma_separated_syntax` に `#[must_use]` 追加
+- **code_actions**: `find_ignore_ascii_case`, `contains_ignore_ascii_case` に `#[must_use]` 追加
+- **formatting**: `should_newline_before`, `needs_space_before`, `should_decrease_indent` に `#[inline]` 追加
+- **symbol_table**: デッドコード `find_identifier_at` とそのテストを削除（Session 19以降未使用）
+- **-45行** (164行削除、119行追加、11ファイル変更)
+- **1089 tests passed** (-1 from find_identifier_at test removal)
 
 ## 🔄 Session 23 成果
 

--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -2,7 +2,7 @@
 
 > **各エージェントへ**: 作業前に必ずこのファイルを読むこと。
 
-**最終更新:** 2026-06-07 / Session 24 (Arc<str> borrow, delta dedup, find_token_at_position)
+**最終更新:** 2026-06-07 / Session 25 (parser #[must_use], format arg inlining)
 
 ---
 
@@ -27,6 +27,7 @@
 | `5c71e83` | perf(hover): use entry.name instead of allocated upper in build_hover_content |
 | `e6938a6` | fix(parser): return ParseError for invalid BINARY length instead of silent default |
 | `e91b0d2` | refactor(parser): add #[must_use] to public parse functions and with_mode |
+| `13da0c8` | style: inline format args across 17 files (clippy uninlined_format_args) |
 
 ### 変更内容
 - **hover/definition/references/rename**: `Arc<str>.clone()` → `&str` 借用に置換（ホットパスでのアトミック参照カウント操作を回避）
@@ -41,6 +42,7 @@
 - **symbol_table**: デッドコード `find_identifier_at` とそのテストを削除（Session 19以降未使用）
 - **parser**: `BINARY(abc)` のような無効な長さ指定がサイレントにデフォルト値1になっていた問題を修正。VARCHAR/DECIMALと同様に `InvalidSyntax` エラーを返すよう変更
 - **parser**: `parse`, `parse_one`, `parse_with_errors`, `with_mode` に `#[must_use]` 追加
+- **全17ファイル**: `format!("{}", var)` → `format!("{var}")` にインライン化（clippy uninlined_format_args）
 - **1089 tests passed** (-1 from find_identifier_at test removal)
 
 ## 🔄 Session 23 成果

--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -2,7 +2,7 @@
 
 > **各エージェントへ**: 作業前に必ずこのファイルを読むこと。
 
-**最終更新:** 2026-06-05 / Session 20 (legacy function removal + PR rebase)
+**最終更新:** 2026-06-06 / Session 21 (code quality improvements + zero-alloc optimizations)
 
 ---
 
@@ -10,12 +10,41 @@
 
 | 項目 | 状態 |
 |------|------|
-| **テスト** | 1043 passed, 2 skipped (master) / 1077 passed, 2 skipped (PR #123) |
+| **テスト** | 1054 passed, 2 skipped (branch refactor/session-21-code-quality) |
 | **Clippy** | clean (`-D warnings`) |
 | **Fmt** | clean |
-| **Open Issues** | 11 |
-| **Open PRs** | 1 (#123, rebased onto latest master) |
-| **ブランチ** | master + feat/insert-column-list-v2 (#123) |
+| **Open Issues** | 12 |
+| **Open PRs** | 2 (#123 INSERT column list, #124 code quality) |
+| **ブランチ** | master + feat/insert-column-list-v2 (#123) + refactor/session-21-code-quality (#124) |
+
+---
+
+## 🔄 Session 21 成果
+
+### コミット（master直接）
+| コミット | 内容 |
+|---------|------|
+| `f077159` | refactor(core): extract constants, add #[must_use], remove allocations, add tests |
+| `d3ece94` | perf(core): replace to_uppercase() with zero-allocation case-insensitive search |
+| `dbaa091` | perf(references): replace to_uppercase() with zero-alloc ends_with_ignore_ascii_case |
+
+### 変更内容
+- **code_actions.rs**: `TRY_CATCH_LABEL` const, `find_ignore_ascii_case`/`contains_ignore_ascii_case` utilities, removed 2x `get_line().to_string()` allocations
+- **completion.rs**: `KEYWORD_DETAIL` const for repeated "T-SQL Keyword" literal
+- **workspace_symbols.rs**: Use `CaseInsensitiveKey.as_str()` instead of per-symbol `name.to_uppercase().contains()`. Macro-based iteration
+- **symbol_table/mod.rs**: `as_str()` accessor on `CaseInsensitiveKey`
+- **references.rs**: `ends_with_ignore_ascii_case()` replaces `trimmed.to_uppercase()` allocation
+- **line_index.rs**: `#[must_use]` on 5 methods
+- **diagnostics.rs**: `#[must_use]` on `diagnose()`
+- **formatting.rs**: `#[must_use]` on `format()`
+- **semantic_tokens.rs**: `#[must_use]` on 2 functions
+- **folding.rs/hover.rs**: doc comments on private functions
+- **+7 tests**: definition (INDEX, variable in WHILE), rename (case-insensitive table, multi-reference), signature_help (CONVERT, GETDATE, SUBSTRING)
+
+### 削減効果
+- 6箇所の不要な `.to_uppercase()` / `.to_string()` アロケーションを除去
+- 12箇所の `#[must_use]` 追加で意図しない戻り値破棄を防止
+- 1050 tests (+7 from 1043)
 
 ---
 

--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -2,7 +2,7 @@
 
 > **各エージェントへ**: 作業前に必ずこのファイルを読むこと。
 
-**最終更新:** 2026-06-06 / Session 21 (code quality improvements + zero-alloc optimizations)
+**最終更新:** 2026-06-06 / Session 21 (code quality + zero-alloc + emitter tests)
 
 ---
 
@@ -10,7 +10,7 @@
 
 | 項目 | 状態 |
 |------|------|
-| **テスト** | 1054 passed, 2 skipped (branch refactor/session-21-code-quality) |
+| **テスト** | 1069 passed, 2 skipped (branch refactor/session-21-code-quality) |
 | **Clippy** | clean (`-D warnings`) |
 | **Fmt** | clean |
 | **Open Issues** | 12 |

--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -2,7 +2,7 @@
 
 > **各エージェントへ**: 作業前に必ずこのファイルを読むこと。
 
-**最終更新:** 2026-06-06 / Session 22 (symbol lookup unification + must_use + tests)
+**最終更新:** 2026-06-06 / Session 22 final (all code quality tasks completed)
 
 ---
 
@@ -13,9 +13,37 @@
 | **テスト** | 1083 passed, 2 skipped (branch refactor/session-21-code-quality) |
 | **Clippy** | clean (`-D warnings`) |
 | **Fmt** | clean |
-| **Open Issues** | 12 |
+| **Coupling** | Grade D (0.39) — emitter→parser依存は構造的、db_docs→DocEntryは同一crate内 |
+| **Open Issues** | 12 (全てLarge機能、コード品質改善なし) |
 | **Open PRs** | 2 (#123 INSERT column list, #124 code quality) |
 | **ブランチ** | master + feat/insert-column-list-v2 (#123) + refactor/session-21-code-quality (#124) |
+
+## ✅ コード品質改善 完了状況
+
+### アロケーション除去
+- ✅ `.to_uppercase()` 11箇所除去（Session 17-22）
+- ✅ `.to_string()` 不要箇所除去（Session 14-15）
+- ✅ `Vec<String>` → `Vec<&str>`（collect_table_names）
+- ✅ `buffer.clone()` → `mem::take`（3 emitter）
+
+### API品質
+- ✅ 全28公開純粋関数に `#[must_use]`（Session 21-22）
+- ✅ 全公開struct field/enum variantにdoc comment（Session 14）
+- ✅ `Debug` derive 追加（DocumentAnalysis, LineIndex）
+- ✅ `find_*` helper 統一（table/procedure/variable/view/index/trigger）
+- ✅ `resolve_semantic_type` メソッド追加
+
+### テストカバレッジ
+- ✅ 1043 → 1083 テスト（+40 over Sessions 7-22）
+- ✅ find_* helper テスト 5件
+- ✅ resolve_semantic_type テスト 6件
+- ✅ definition テスト 4件（view, trigger, case-insensitive, multi-object）
+- ✅ emitter integration テスト追加
+
+### 残る改善は大規模リファクタリングのみ
+- レガシー関数削除（50+テスト移行が必要）→ 別PRで対応
+- 結合度Grade D改善 → アーキテクチャ変更（trait導入等）が必要
+- 残りのOpen Issues → 全てLarge規模の新機能追加
 
 ---
 

--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -2,7 +2,7 @@
 
 > **各エージェントへ**: 作業前に必ずこのファイルを読むこと。
 
-**最終更新:** 2026-06-06 / Session 21 (code quality + zero-alloc + emitter tests)
+**最終更新:** 2026-06-06 / Session 22 (symbol lookup unification + must_use + tests)
 
 ---
 
@@ -10,12 +10,43 @@
 
 | 項目 | 状態 |
 |------|------|
-| **テスト** | 1069 passed, 2 skipped (branch refactor/session-21-code-quality) |
+| **テスト** | 1083 passed, 2 skipped (branch refactor/session-21-code-quality) |
 | **Clippy** | clean (`-D warnings`) |
 | **Fmt** | clean |
 | **Open Issues** | 12 |
 | **Open PRs** | 2 (#123 INSERT column list, #124 code quality) |
 | **ブランチ** | master + feat/insert-column-list-v2 (#123) + refactor/session-21-code-quality (#124) |
+
+---
+
+## 🔄 Session 22 成果
+
+### コミット（PR #124 ブランチ）
+| コミット | 内容 |
+|---------|------|
+| `e08845e` | refactor(core): add #[must_use] to all remaining pure LSP handler functions |
+| `b7416f4` | test(core): add tests for new find_* helpers and resolve_semantic_type |
+| `b7b8015` | refactor(core): unify symbol lookups, eliminate to_uppercase() in definition/hover/semantic_tokens |
+
+### コミット（PR #123 ブランチ）
+| コミット | 内容 |
+|---------|------|
+| `0cd82a1` | refactor(code_actions): use make_quickfix helper for INSERT column list action |
+
+### 変更内容
+- **symbol_table/mod.rs**: `find_view`, `find_index`, `find_trigger` helpers, `SymbolTable::resolve_semantic_type` method
+- **definition.rs**: Replace direct HashMap::get with case-insensitive find_* helpers, eliminate `.to_uppercase()`, add `#[must_use]`
+- **hover.rs**: `collect_table_names` returns `Vec<&str>` (zero-alloc borrows), use `find_*` + `eq_ignore_ascii_case` throughout, add `#[must_use]`
+- **semantic_tokens.rs**: Delegate to `SymbolTable::resolve_semantic_type` (single allocation), add `#[must_use]`
+- **references.rs, rename.rs, folding.rs, symbols.rs, workspace_symbols.rs, signature_help.rs, code_actions.rs**: `#[must_use]` on all public pure functions
+- **db_docs/mod.rs**: `#[must_use]` on all 6 lookup/accessor functions
+- **code_actions.rs (PR #123)**: Use `make_quickfix` helper for INSERT column list action (CodeRabbit review feedback)
+
+### 削減効果
+- 5箇所の `.to_uppercase()` アロケーションを除去（definition + hover）
+- `collect_table_names` の `Vec<String>` → `Vec<&str>` でテーブル名ごとのアロケーション除去
+- 全28の公開純粋関数に `#[must_use]` 追加完了
+- +14テスト（find_view/index/trigger 5件, resolve_semantic_type 6件, definition 4件, CodeRabbit指摘対応既存）
 
 ---
 

--- a/WHITEBOARD.md
+++ b/WHITEBOARD.md
@@ -10,7 +10,7 @@
 
 | 項目 | 状態 |
 |------|------|
-| **テスト** | 1083 passed, 2 skipped (branch refactor/session-21-code-quality) |
+| **テスト** | 1090 passed, 2 skipped (branch refactor/session-21-code-quality) |
 | **Clippy** | clean (`-D warnings`) |
 | **Fmt** | clean |
 | **Coupling** | Grade D (0.39) — emitter→parser依存は構造的、db_docs→DocEntryは同一crate内 |
@@ -27,6 +27,7 @@
 | `8267468` | refactor: add const fn to 29 pure functions across 4 crates |
 | `7114367` | perf(core): add #[inline] to hot-path LineIndex and DocumentAnalysis accessors |
 | `3c9ec2b` | perf(core): change OwnedToken.text from String to Arc<str> |
+| `2c5005a` | test(core): add 7 edge-case tests for signature_help and semantic_tokens |
 
 ### 変更内容
 - **server.rs**: `DocumentStore`が`Arc<DocumentAnalysis>`を格納。`get_analysis()`が`Option<Arc<DocumentAnalysis>>`を返す。Deref coercionで呼び出し元は`&DocumentAnalysis`を透過的に取得
@@ -41,6 +42,7 @@
 - `const fn` 29箇所: コンパイラの最適化ヒント + 純粋性の型レベル表明
 - `#[inline]` 7箇所: ホットパスの関数呼び出しオーバーヘッドを除去
 - `Arc<str>` for OwnedToken.text: 4ハンドラの`.clone()`がO(n)→O(1)に
+- +7テスト: signature_help (4件: 空ソース/括弧外/グループ化/複数行), semantic_tokens (3件: 変数/データ型/範囲境界)
 
 ## ✅ コード品質改善 完了状況
 

--- a/crates/ase-ls-core/src/analysis.rs
+++ b/crates/ase-ls-core/src/analysis.rs
@@ -98,6 +98,7 @@ impl DocumentAnalysis {
 
     /// Find the token at a given byte offset using binary search. O(log n).
     #[must_use]
+    #[inline]
     pub fn find_token_at(&self, offset: usize) -> Option<(&OwnedToken, usize)> {
         let idx = self
             .tokens
@@ -116,6 +117,7 @@ impl DocumentAnalysis {
 
     /// Get the text of a specific line. O(1) line lookup via LineIndex.
     #[must_use]
+    #[inline]
     pub fn get_line(&self, line: u32) -> &str {
         let line_count = self.line_index.line_count();
         let line = line as usize;

--- a/crates/ase-ls-core/src/analysis.rs
+++ b/crates/ase-ls-core/src/analysis.rs
@@ -5,6 +5,7 @@
 
 use crate::line_index::LineIndex;
 use crate::symbol_table::{SymbolTable, SymbolTableBuilder};
+use std::sync::Arc;
 use tsql_token::{Span, TokenKind};
 
 /// Owned copy of a lexer token, without lifetime dependency on source.
@@ -12,8 +13,8 @@ use tsql_token::{Span, TokenKind};
 pub struct OwnedToken {
     /// Token kind (keyword, identifier, operator, etc.)
     pub kind: TokenKind,
-    /// Token text (cloned from source).
-    pub text: String,
+    /// Token text (Arc<str> for O(1) clone on hot-path handler access).
+    pub text: Arc<str>,
     /// Byte span in source.
     pub span: Span,
 }
@@ -47,7 +48,7 @@ impl DocumentAnalysis {
             .filter_map(|r| r.ok())
             .map(|t| OwnedToken {
                 kind: t.kind,
-                text: t.text.to_string(),
+                text: Arc::from(t.text),
                 span: t.span,
             })
             .collect();
@@ -196,7 +197,7 @@ mod tests {
         assert!(!analysis.tokens.is_empty());
         // First token should be SELECT
         assert_eq!(analysis.tokens[0].kind, TokenKind::Select);
-        assert_eq!(analysis.tokens[0].text, "SELECT");
+        assert_eq!(&*analysis.tokens[0].text, "SELECT");
     }
 
     #[test]
@@ -240,14 +241,14 @@ mod tests {
         let analysis = DocumentAnalysis::new("SELECT * FROM users");
         let (token, _) = analysis.find_token_at(0).unwrap();
         assert_eq!(token.kind, TokenKind::Select);
-        assert_eq!(token.text, "SELECT");
+        assert_eq!(&*token.text, "SELECT");
     }
 
     #[test]
     fn test_find_token_at_mid() {
         let analysis = DocumentAnalysis::new("SELECT * FROM users");
         let (token, _) = analysis.find_token_at(3).unwrap();
-        assert_eq!(token.text, "SELECT");
+        assert_eq!(&*token.text, "SELECT");
     }
 
     #[test]
@@ -268,7 +269,7 @@ mod tests {
         let analysis = DocumentAnalysis::new("DECLARE @count INT");
         let (token, _) = analysis.find_token_at(8).unwrap();
         assert_eq!(token.kind, TokenKind::LocalVar);
-        assert_eq!(token.text, "@count");
+        assert_eq!(&*token.text, "@count");
     }
 
     // --- get_line() tests (Phase 2-C: O(1) line lookup) ---

--- a/crates/ase-ls-core/src/analysis.rs
+++ b/crates/ase-ls-core/src/analysis.rs
@@ -116,6 +116,20 @@ impl DocumentAnalysis {
         }
     }
 
+    /// Convert an LSP Position to a byte offset, then find the token at that offset.
+    ///
+    /// Convenience method that combines `LineIndex::position_to_offset` and
+    /// `find_token_at`, eliminating a repeated pattern across LSP handlers.
+    #[must_use]
+    #[inline]
+    pub fn find_token_at_position(
+        &self,
+        position: lsp_types::Position,
+    ) -> Option<(&OwnedToken, usize)> {
+        let offset = self.line_index.position_to_offset(&self.source, position);
+        self.find_token_at(offset)
+    }
+
     /// Get the text of a specific line. O(1) line lookup via LineIndex.
     #[must_use]
     #[inline]

--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -19,6 +19,7 @@ use tsql_token::TokenKind;
 const TRY_CATCH_LABEL: &str = "Wrap with TRY...CATCH";
 
 /// Code Actionsを生成する（DocumentAnalysis利用）
+#[must_use]
 pub fn code_actions_with_analysis(
     analysis: &DocumentAnalysis,
     range: Range,

--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -249,10 +249,7 @@ fn try_generate_insert_skeleton_ast(
     let placeholders = vec!["?"; columns.len()];
     let values_list = placeholders.join(", ");
 
-    let new_text = format!(
-        "INSERT INTO {} ({}) VALUES ({})",
-        table_name, col_list, values_list
-    );
+    let new_text = format!("INSERT INTO {table_name} ({col_list}) VALUES ({values_list})");
 
     // Replace the entire INSERT statement span
     let edit = make_text_edit(
@@ -347,10 +344,7 @@ fn try_generate_insert_skeleton(
     let placeholders = vec!["?"; columns.len()];
     let values_list = placeholders.join(", ");
 
-    let new_text = format!(
-        "INSERT INTO {} ({}) VALUES ({})",
-        table_name, col_list, values_list
-    );
+    let new_text = format!("INSERT INTO {table_name} ({col_list}) VALUES ({values_list})");
 
     let edit = make_text_edit(
         uri,

--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -637,7 +637,7 @@ fn make_text_edit(uri: &lsp_types::Url, range: Range, new_text: String) -> Works
 }
 
 /// Create a quick-fix CodeAction with standard fields.
-fn make_quickfix(title: String, edit: WorkspaceEdit) -> CodeAction {
+const fn make_quickfix(title: String, edit: WorkspaceEdit) -> CodeAction {
     CodeAction {
         title,
         kind: Some(CodeActionKind::QUICKFIX),
@@ -651,7 +651,7 @@ fn make_quickfix(title: String, edit: WorkspaceEdit) -> CodeAction {
 }
 
 /// Create a refactor CodeAction with standard fields.
-fn make_refactor(title: String, edit: WorkspaceEdit) -> CodeAction {
+const fn make_refactor(title: String, edit: WorkspaceEdit) -> CodeAction {
     CodeAction {
         title,
         kind: Some(CodeActionKind::REFACTOR),

--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -270,6 +270,7 @@ fn try_generate_insert_skeleton_ast(
 
 /// Find a case-insensitive ASCII substring, returning the byte offset.
 /// Returns None if the needle is not found.
+#[inline]
 fn find_ignore_ascii_case(haystack: &str, needle: &str) -> Option<usize> {
     if needle.is_empty() {
         return Some(0);
@@ -291,6 +292,7 @@ fn find_ignore_ascii_case(haystack: &str, needle: &str) -> Option<usize> {
 }
 
 /// Check if haystack contains needle (case-insensitive ASCII) without allocation.
+#[inline]
 fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
     find_ignore_ascii_case(haystack, needle).is_some()
 }

--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -271,6 +271,7 @@ fn try_generate_insert_skeleton_ast(
 
 /// Find a case-insensitive ASCII substring, returning the byte offset.
 /// Returns None if the needle is not found.
+#[must_use]
 #[inline]
 fn find_ignore_ascii_case(haystack: &str, needle: &str) -> Option<usize> {
     if needle.is_empty() {
@@ -293,6 +294,7 @@ fn find_ignore_ascii_case(haystack: &str, needle: &str) -> Option<usize> {
 }
 
 /// Check if haystack contains needle (case-insensitive ASCII) without allocation.
+#[must_use]
 #[inline]
 fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
     find_ignore_ascii_case(haystack, needle).is_some()

--- a/crates/ase-ls-core/src/code_actions.rs
+++ b/crates/ase-ls-core/src/code_actions.rs
@@ -1270,4 +1270,40 @@ mod tests {
             "TRY...CATCH wrap should be offered for BEGIN block inside CREATE TRIGGER"
         );
     }
+
+    #[test]
+    fn test_find_ignore_ascii_case_basic() {
+        assert_eq!(
+            find_ignore_ascii_case("insert into t", "INSERT INTO"),
+            Some(0)
+        );
+        assert_eq!(
+            find_ignore_ascii_case("INSERT INTO t", "insert into"),
+            Some(0)
+        );
+        assert_eq!(
+            find_ignore_ascii_case("  insert into t", "INSERT INTO"),
+            Some(2)
+        );
+        assert_eq!(
+            find_ignore_ascii_case("select * from t", "INSERT INTO"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_ignore_ascii_case_edge_cases() {
+        assert_eq!(find_ignore_ascii_case("", ""), Some(0));
+        assert_eq!(find_ignore_ascii_case("abc", ""), Some(0));
+        assert_eq!(find_ignore_ascii_case("", "abc"), None);
+        assert_eq!(find_ignore_ascii_case("ab", "abc"), None);
+    }
+
+    #[test]
+    fn test_contains_ignore_ascii_case() {
+        assert!(contains_ignore_ascii_case("insert into t values", "VALUES"));
+        assert!(contains_ignore_ascii_case("insert into t Values", "VALUES"));
+        assert!(contains_ignore_ascii_case("insert into t select", "SELECT"));
+        assert!(!contains_ignore_ascii_case("insert into t", "VALUES"));
+    }
 }

--- a/crates/ase-ls-core/src/completion.rs
+++ b/crates/ase-ls-core/src/completion.rs
@@ -24,6 +24,7 @@ const KEYWORD_DETAIL: &str = "T-SQL Keyword";
 /// - `build_function_snippet("SUBSTRING", &["expression", "start", "length"])`
 ///   → `SUBSTRING(${1:expression}, ${2:start}, ${3:length})`
 /// - `build_function_snippet("GETDATE", &[])` → `GETDATE()`
+#[must_use]
 pub(crate) fn build_function_snippet(name: &str, params: &[&str]) -> String {
     if params.is_empty() {
         return format!("{name}()");
@@ -41,6 +42,7 @@ pub(crate) fn build_function_snippet(name: &str, params: &[&str]) -> String {
 /// カンマ区切りではない関数（`CAST(expr AS type)`等）や
 /// 括弧なしの関数（`IDENTITY`等）はsnippetプレースホルダー生成に
 /// 適さないためfalseを返す。
+#[must_use]
 fn is_comma_separated_syntax(syntax: &str) -> bool {
     if let (Some(open), Some(close)) = (syntax.find('('), syntax.rfind(')')) {
         if open < close {

--- a/crates/ase-ls-core/src/db_docs/mod.rs
+++ b/crates/ase-ls-core/src/db_docs/mod.rs
@@ -70,12 +70,14 @@ static OTHER_LOOKUP: LazyLock<HashMap<&'static str, &'static DocEntry>> = LazyLo
 });
 
 /// 名前（大文字）で関数 DocEntry を検索する
+#[must_use]
 pub fn lookup_function(name: &str) -> Option<&'static DocEntry> {
     FUNCTION_LOOKUP.get(name).copied()
 }
 
 /// 名前（大文字）で DocEntry を検索する
 /// キーワードと関数で名前が重複する場合（例: LEFT）、キーワードを優先する
+#[must_use]
 pub fn lookup(name: &str) -> Option<&'static DocEntry> {
     OTHER_LOOKUP
         .get(name)
@@ -84,21 +86,25 @@ pub fn lookup(name: &str) -> Option<&'static DocEntry> {
 }
 
 /// キーワードエントリのスライスを返す
+#[must_use]
 pub fn keywords() -> &'static [DocEntry] {
     KEYWORD_ENTRIES
 }
 
 /// データ型エントリのスライスを返す
+#[must_use]
 pub fn datatypes() -> &'static [DocEntry] {
     DATATYPE_ENTRIES
 }
 
 /// 関数エントリのスライスを返す
+#[must_use]
 pub fn functions() -> &'static [DocEntry] {
     FUNCTION_ENTRIES
 }
 
 /// システム変数エントリのスライスを返す
+#[must_use]
 pub fn system_variables() -> &'static [DocEntry] {
     SYSTEM_VARIABLE_ENTRIES
 }

--- a/crates/ase-ls-core/src/definition.rs
+++ b/crates/ase-ls-core/src/definition.rs
@@ -194,4 +194,78 @@ mod tests {
         );
         assert_eq!(ranges.len(), 1);
     }
+
+    #[test]
+    fn test_definition_with_analysis_view() {
+        let analysis = crate::analysis::DocumentAnalysis::new(
+            "CREATE VIEW active_users AS SELECT * FROM users\nSELECT * FROM active_users",
+        );
+        let ranges = definition_ranges_with_analysis(
+            &analysis,
+            Position {
+                line: 1,
+                character: 17,
+            },
+        );
+        assert_eq!(ranges.len(), 1, "Should find view definition");
+        assert_eq!(ranges[0].start.line, 0, "View definition should be on line 0");
+    }
+
+    #[test]
+    fn test_definition_with_analysis_trigger() {
+        let analysis = crate::analysis::DocumentAnalysis::new(
+            "CREATE TRIGGER tr_test ON users FOR INSERT AS BEGIN SELECT 1 END",
+        );
+        let ranges = definition_ranges_with_analysis(
+            &analysis,
+            Position {
+                line: 0,
+                character: 18,
+            },
+        );
+        assert_eq!(ranges.len(), 1, "Should find trigger definition");
+    }
+
+    #[test]
+    fn test_definition_case_insensitive() {
+        let analysis = crate::analysis::DocumentAnalysis::new(
+            "CREATE TABLE Users (id INT)\nSELECT * FROM users",
+        );
+        let ranges = definition_ranges_with_analysis(
+            &analysis,
+            Position {
+                line: 1,
+                character: 15,
+            },
+        );
+        assert_eq!(ranges.len(), 1, "Case-insensitive table lookup should work");
+    }
+
+    #[test]
+    fn test_definition_multiple_object_types() {
+        let source =
+            "CREATE TABLE t (id INT)\nCREATE VIEW v AS SELECT * FROM t\nCREATE INDEX idx ON t (id)";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        // Table definition from line 1 "FROM t" — 't' is at char 31
+        let ranges = definition_ranges_with_analysis(
+            &analysis,
+            Position {
+                line: 1,
+                character: 31,
+            },
+        );
+        assert!(
+            !ranges.is_empty(),
+            "Should find table definition from view's FROM clause"
+        );
+        // View definition — 'v' is at line 1, char 12
+        let ranges = definition_ranges_with_analysis(
+            &analysis,
+            Position {
+                line: 1,
+                character: 12,
+            },
+        );
+        assert!(!ranges.is_empty(), "Should find view definition");
+    }
 }

--- a/crates/ase-ls-core/src/definition.rs
+++ b/crates/ase-ls-core/src/definition.rs
@@ -15,6 +15,7 @@ use lsp_types::{Position, Range};
 use tsql_token::TokenKind;
 
 /// カーソル位置のシンボルの定義箇所を検索する（DocumentAnalysis利用）
+#[must_use]
 pub fn definition_ranges_with_analysis(
     analysis: &DocumentAnalysis,
     position: Position,

--- a/crates/ase-ls-core/src/definition.rs
+++ b/crates/ase-ls-core/src/definition.rs
@@ -9,7 +9,7 @@
 //! - インデックス参照 → CREATE INDEX定義
 
 use crate::analysis::DocumentAnalysis;
-use crate::symbol_table::SymbolTable;
+use crate::symbol_table::SymbolTableBuilder;
 
 use lsp_types::{Position, Range};
 use tsql_token::TokenKind;
@@ -28,22 +28,19 @@ pub fn definition_ranges_with_analysis(
         None => return Vec::new(),
     };
 
-    let search_name = target_text.to_uppercase();
-
     if target_kind == TokenKind::LocalVar {
-        find_variable_definition(&analysis.symbol_table, &search_name)
+        find_variable_definition(&analysis.symbol_table, &target_text)
     } else {
-        find_object_definition(&analysis.symbol_table, &search_name)
+        find_object_definition(&analysis.symbol_table, &target_text)
     }
 }
 
 /// 変数定義を検索する
-fn find_variable_definition(table: &SymbolTable, name: &str) -> Vec<Range> {
-    // プロシージャ内変数を含めて検索
+fn find_variable_definition(table: &crate::symbol_table::SymbolTable, name: &str) -> Vec<Range> {
     let mut results = Vec::new();
 
     // トップレベル変数
-    if let Some(var) = table.variables.get(name) {
+    if let Some(var) = SymbolTableBuilder::find_variable(table, name) {
         results.push(var.range);
     }
 
@@ -66,22 +63,22 @@ fn find_variable_definition(table: &SymbolTable, name: &str) -> Vec<Range> {
 }
 
 /// オブジェクト定義（テーブル、プロシージャ、ビュー、インデックス、トリガー）を検索する
-fn find_object_definition(table: &SymbolTable, name: &str) -> Vec<Range> {
+fn find_object_definition(table: &crate::symbol_table::SymbolTable, name: &str) -> Vec<Range> {
     let mut results = Vec::new();
 
-    if let Some(tbl) = table.tables.get(name) {
+    if let Some(tbl) = SymbolTableBuilder::find_table(table, name) {
         results.push(tbl.range);
     }
-    if let Some(proc) = table.procedures.get(name) {
+    if let Some(proc) = SymbolTableBuilder::find_procedure(table, name) {
         results.push(proc.range);
     }
-    if let Some(view) = table.views.get(name) {
+    if let Some(view) = SymbolTableBuilder::find_view(table, name) {
         results.push(view.range);
     }
-    if let Some(idx) = table.indexes.get(name) {
+    if let Some(idx) = SymbolTableBuilder::find_index(table, name) {
         results.push(idx.range);
     }
-    if let Some(trigger) = table.triggers.get(name) {
+    if let Some(trigger) = SymbolTableBuilder::find_trigger(table, name) {
         results.push(trigger.range);
     }
 

--- a/crates/ase-ls-core/src/definition.rs
+++ b/crates/ase-ls-core/src/definition.rs
@@ -20,19 +20,15 @@ pub fn definition_ranges_with_analysis(
     analysis: &DocumentAnalysis,
     position: Position,
 ) -> Vec<Range> {
-    let offset = analysis
-        .line_index
-        .position_to_offset(&analysis.source, position);
-
-    let (target_kind, target_text) = match analysis.find_token_at(offset) {
-        Some((t, _)) => (t.kind, t.text.clone()),
+    let (target_kind, target_text) = match analysis.find_token_at_position(position) {
+        Some((t, _)) => (t.kind, &*t.text),
         None => return Vec::new(),
     };
 
     if target_kind == TokenKind::LocalVar {
-        find_variable_definition(&analysis.symbol_table, &target_text)
+        find_variable_definition(&analysis.symbol_table, target_text)
     } else {
-        find_object_definition(&analysis.symbol_table, &target_text)
+        find_object_definition(&analysis.symbol_table, target_text)
     }
 }
 

--- a/crates/ase-ls-core/src/definition.rs
+++ b/crates/ase-ls-core/src/definition.rs
@@ -209,7 +209,10 @@ mod tests {
             },
         );
         assert_eq!(ranges.len(), 1, "Should find view definition");
-        assert_eq!(ranges[0].start.line, 0, "View definition should be on line 0");
+        assert_eq!(
+            ranges[0].start.line, 0,
+            "View definition should be on line 0"
+        );
     }
 
     #[test]

--- a/crates/ase-ls-core/src/folding.rs
+++ b/crates/ase-ls-core/src/folding.rs
@@ -9,6 +9,7 @@ use tsql_parser::ast::Statement;
 use tsql_token::TokenKind;
 
 /// Folding Ranges を DocumentAnalysis から生成する
+#[must_use]
 pub fn folding_ranges_with_analysis(
     analysis: &crate::analysis::DocumentAnalysis,
 ) -> Vec<FoldingRange> {

--- a/crates/ase-ls-core/src/formatting.rs
+++ b/crates/ase-ls-core/src/formatting.rs
@@ -119,7 +119,7 @@ fn format_token<'a>(kind: &TokenKind, text: &'a str) -> Cow<'a, str> {
 }
 
 /// トークン前に改行を入れるべきか
-fn should_newline_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bool {
+const fn should_newline_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bool {
     let prev = match prev {
         Some(p) => p,
         None => return false,
@@ -181,7 +181,7 @@ fn should_newline_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bool {
 }
 
 /// トークン前にスペースを入れるべきか
-fn needs_space_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bool {
+const fn needs_space_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bool {
     let prev = match prev {
         Some(p) => p,
         None => return false,
@@ -206,7 +206,7 @@ fn needs_space_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bool {
 }
 
 /// トークン出力前にインデントを減らすべきか
-fn should_decrease_indent(kind: &TokenKind) -> bool {
+const fn should_decrease_indent(kind: &TokenKind) -> bool {
     matches!(kind, TokenKind::End | TokenKind::End_)
 }
 

--- a/crates/ase-ls-core/src/formatting.rs
+++ b/crates/ase-ls-core/src/formatting.rs
@@ -119,6 +119,7 @@ fn format_token<'a>(kind: &TokenKind, text: &'a str) -> Cow<'a, str> {
 }
 
 /// トークン前に改行を入れるべきか
+#[inline]
 const fn should_newline_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bool {
     let prev = match prev {
         Some(p) => p,
@@ -181,6 +182,7 @@ const fn should_newline_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bo
 }
 
 /// トークン前にスペースを入れるべきか
+#[inline]
 const fn needs_space_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bool {
     let prev = match prev {
         Some(p) => p,
@@ -206,6 +208,7 @@ const fn needs_space_before(kind: &TokenKind, prev: Option<&TokenKind>) -> bool 
 }
 
 /// トークン出力前にインデントを減らすべきか
+#[inline]
 const fn should_decrease_indent(kind: &TokenKind) -> bool {
     matches!(kind, TokenKind::End | TokenKind::End_)
 }

--- a/crates/ase-ls-core/src/hover.rs
+++ b/crates/ase-ls-core/src/hover.rs
@@ -93,12 +93,15 @@ fn in_span(offset: usize, span_start: usize, span_end: u32) -> bool {
 }
 
 /// Collect table names from a list of TableReference, including JOINed tables.
-fn collect_table_names(tables: &[TableReference]) -> Vec<String> {
+///
+/// Returns borrowed `&str` references to avoid allocation — the caller passes
+/// them to `SymbolTableBuilder::find_table` which handles case-insensitivity.
+fn collect_table_names(tables: &[TableReference]) -> Vec<&str> {
     let mut names = Vec::new();
     for tr in tables {
         match tr {
             TableReference::Table { name, .. } => {
-                names.push(name.name.to_uppercase());
+                names.push(name.name.as_str());
             }
             TableReference::Joined { joins, .. } => {
                 for join in joins {
@@ -148,9 +151,8 @@ fn resolve_column_in_statement(
             }
 
             // Check inserted columns
-            let table_name = insert.table.name.to_uppercase();
             if let Some(tbl) =
-                crate::symbol_table::SymbolTableBuilder::find_table(symbol_table, &table_name)
+                crate::symbol_table::SymbolTableBuilder::find_table(symbol_table, &insert.table.name)
             {
                 for col in &tbl.columns {
                     if col.name.eq_ignore_ascii_case(upper_ident) {
@@ -166,11 +168,11 @@ fn resolve_column_in_statement(
             }
 
             let table_name = match &update.table {
-                TableReference::Table { name, .. } => name.name.to_uppercase(),
+                TableReference::Table { name, .. } => name.name.as_str(),
                 _ => return None,
             };
             // Collect tables from both the UPDATE target and FROM clause
-            let mut all_tables = vec![table_name.clone()];
+            let mut all_tables: Vec<&str> = vec![table_name];
             if let Some(from_clause) = &update.from_clause {
                 all_tables.extend(collect_table_names(&from_clause.tables));
             }
@@ -232,14 +234,12 @@ fn build_schema_hover(
     kind: &TokenKind,
     text: &str,
 ) -> Option<String> {
-    let upper = text.to_uppercase();
+    use crate::symbol_table::SymbolTableBuilder;
 
     match kind {
         TokenKind::LocalVar => {
             // 変数の型情報を表示
-            if let Some(var) =
-                crate::symbol_table::SymbolTableBuilder::find_variable(symbol_table, text)
-            {
+            if let Some(var) = SymbolTableBuilder::find_variable(symbol_table, text) {
                 return Some(format!(
                     "```tsql\n{}: {}\n```\n\n**Variable** — Declared with `DECLARE {} {}`",
                     text, var.data_type, var.name, var.data_type
@@ -248,7 +248,7 @@ fn build_schema_hover(
             // プロシージャボディ内変数
             for proc in symbol_table.procedures.values() {
                 for body_var in &proc.body_variables {
-                    if body_var.name.eq_ignore_ascii_case(&upper) {
+                    if body_var.name.eq_ignore_ascii_case(text) {
                         return Some(format!(
                             "```tsql\n{}: {}\n```\n\n**Variable** in `{}` — `DECLARE {} {}`",
                             text, body_var.data_type, proc.name, body_var.name, body_var.data_type
@@ -256,7 +256,7 @@ fn build_schema_hover(
                     }
                 }
                 for param in &proc.parameters {
-                    if param.name.eq_ignore_ascii_case(&upper) {
+                    if param.name.eq_ignore_ascii_case(text) {
                         let output_marker = if param.is_output { " OUTPUT" } else { "" };
                         return Some(format!(
                             "```tsql\n{}: {}{}\n```\n\n**Parameter** of `{}`",
@@ -269,7 +269,7 @@ fn build_schema_hover(
         }
         TokenKind::Ident => {
             // テーブルのカラム情報を表示
-            if let Some(table) = symbol_table.tables.get(&upper) {
+            if let Some(table) = SymbolTableBuilder::find_table(symbol_table, text) {
                 let mut cols = String::new();
                 for col in &table.columns {
                     let nullable = match col.nullable {
@@ -292,7 +292,7 @@ fn build_schema_hover(
                 ));
             }
             // プロシージャ情報を表示
-            if let Some(proc) = symbol_table.procedures.get(&upper) {
+            if let Some(proc) = SymbolTableBuilder::find_procedure(symbol_table, text) {
                 let mut params = String::new();
                 for p in &proc.parameters {
                     let output = if p.is_output { " OUTPUT" } else { "" };
@@ -307,11 +307,11 @@ fn build_schema_hover(
                 ));
             }
             // ビュー情報を表示
-            if let Some(_view) = symbol_table.views.get(&upper) {
+            if let Some(_view) = SymbolTableBuilder::find_view(symbol_table, text) {
                 return Some(format!("**`{}`** — View", text));
             }
             // インデックス情報を表示
-            if let Some(idx) = symbol_table.indexes.get(&upper) {
+            if let Some(idx) = SymbolTableBuilder::find_index(symbol_table, text) {
                 let unique = if idx.is_unique { "UNIQUE " } else { "" };
                 let cols = idx.columns.join(", ");
                 return Some(format!(
@@ -326,7 +326,7 @@ fn build_schema_hover(
                 ));
             }
             // トリガー情報を表示
-            if let Some(trigger) = symbol_table.triggers.get(&upper) {
+            if let Some(trigger) = SymbolTableBuilder::find_trigger(symbol_table, text) {
                 let events = trigger.events.join(", ");
                 return Some(format!(
                     "```tsql\nCREATE TRIGGER {} ON {} FOR {}\n```\n\n**Trigger** — on `{}`",

--- a/crates/ase-ls-core/src/hover.rs
+++ b/crates/ase-ls-core/src/hover.rs
@@ -57,11 +57,9 @@ fn build_column_hover(
     offset: usize,
     ident_text: &str,
 ) -> Option<String> {
-    let upper_ident = ident_text.to_uppercase();
-
     for stmt in &analysis.statements {
         if let Some(result) =
-            resolve_column_in_statement(stmt, &analysis.symbol_table, offset, &upper_ident)
+            resolve_column_in_statement(stmt, &analysis.symbol_table, offset, ident_text)
         {
             return Some(result);
         }

--- a/crates/ase-ls-core/src/hover.rs
+++ b/crates/ase-ls-core/src/hover.rs
@@ -11,25 +11,21 @@ use tsql_token::TokenKind;
 /// Hover情報を生成する（DocumentAnalysis利用）
 #[must_use]
 pub fn hover_with_analysis(analysis: &DocumentAnalysis, position: Position) -> Option<Hover> {
-    let offset = analysis
-        .line_index
-        .position_to_offset(&analysis.source, position);
-
-    let (token, _idx) = match analysis.find_token_at(offset) {
+    let (token, _idx) = match analysis.find_token_at_position(position) {
         Some(t) => t,
         None => {
-            tracing::debug!("hover: no token found at offset {offset}");
+            tracing::debug!("hover: no token found at position {:?}", position);
             return None;
         }
     };
     let kind = token.kind;
-    let text = token.text.clone();
+    let text: &str = &token.text;
     let start = token.span.start as usize;
     let end = token.span.end as usize;
 
-    let content = build_schema_hover(&analysis.symbol_table, &kind, &text)
-        .or_else(|| build_column_hover(analysis, offset, &text))
-        .or_else(|| build_hover_content(&kind, &text));
+    let content = build_schema_hover(&analysis.symbol_table, &kind, text)
+        .or_else(|| build_column_hover(analysis, start, text))
+        .or_else(|| build_hover_content(&kind, text));
     let content = match content {
         Some(c) => c,
         None => {

--- a/crates/ase-ls-core/src/hover.rs
+++ b/crates/ase-ls-core/src/hover.rs
@@ -9,6 +9,7 @@ use tsql_parser::ast::{Statement, TableReference};
 use tsql_token::TokenKind;
 
 /// Hover情報を生成する（DocumentAnalysis利用）
+#[must_use]
 pub fn hover_with_analysis(analysis: &DocumentAnalysis, position: Position) -> Option<Hover> {
     let offset = analysis
         .line_index

--- a/crates/ase-ls-core/src/hover.rs
+++ b/crates/ase-ls-core/src/hover.rs
@@ -305,7 +305,7 @@ fn build_schema_hover(
             }
             // ビュー情報を表示
             if let Some(_view) = SymbolTableBuilder::find_view(symbol_table, text) {
-                return Some(format!("**`{}`** — View", text));
+                return Some(format!("**`{text}`** — View"));
             }
             // インデックス情報を表示
             if let Some(idx) = SymbolTableBuilder::find_index(symbol_table, text) {

--- a/crates/ase-ls-core/src/hover.rs
+++ b/crates/ase-ls-core/src/hover.rs
@@ -120,7 +120,7 @@ fn resolve_column_in_statement(
     stmt: &Statement,
     symbol_table: &crate::symbol_table::SymbolTable,
     offset: usize,
-    upper_ident: &str,
+    ident_text: &str,
 ) -> Option<String> {
     match stmt {
         Statement::Select(sel) => {
@@ -138,7 +138,7 @@ fn resolve_column_in_statement(
                     crate::symbol_table::SymbolTableBuilder::find_table(symbol_table, table_name)
                 {
                     for col in &tbl.columns {
-                        if col.name.eq_ignore_ascii_case(upper_ident) {
+                        if col.name.eq_ignore_ascii_case(ident_text) {
                             return Some(format_column_hover(col, &tbl.name));
                         }
                     }
@@ -156,7 +156,7 @@ fn resolve_column_in_statement(
                 crate::symbol_table::SymbolTableBuilder::find_table(symbol_table, &insert.table.name)
             {
                 for col in &tbl.columns {
-                    if col.name.eq_ignore_ascii_case(upper_ident) {
+                    if col.name.eq_ignore_ascii_case(ident_text) {
                         return Some(format_column_hover(col, &tbl.name));
                     }
                 }
@@ -182,7 +182,7 @@ fn resolve_column_in_statement(
                     crate::symbol_table::SymbolTableBuilder::find_table(symbol_table, tbl_name)
                 {
                     for col in &tbl.columns {
-                        if col.name.eq_ignore_ascii_case(upper_ident) {
+                        if col.name.eq_ignore_ascii_case(ident_text) {
                             return Some(format_column_hover(col, &tbl.name));
                         }
                     }
@@ -191,18 +191,18 @@ fn resolve_column_in_statement(
             None
         }
         Statement::Block(block) => block.statements.iter().find_map(|child| {
-            resolve_column_in_statement(child, symbol_table, offset, upper_ident)
+            resolve_column_in_statement(child, symbol_table, offset, ident_text)
         }),
         Statement::If(if_stmt) => {
-            resolve_column_in_statement(&if_stmt.then_branch, symbol_table, offset, upper_ident)
+            resolve_column_in_statement(&if_stmt.then_branch, symbol_table, offset, ident_text)
                 .or_else(|| {
                     if_stmt.else_branch.as_ref().and_then(|else_b| {
-                        resolve_column_in_statement(else_b, symbol_table, offset, upper_ident)
+                        resolve_column_in_statement(else_b, symbol_table, offset, ident_text)
                     })
                 })
         }
         Statement::While(while_stmt) => {
-            resolve_column_in_statement(&while_stmt.body, symbol_table, offset, upper_ident)
+            resolve_column_in_statement(&while_stmt.body, symbol_table, offset, ident_text)
         }
         Statement::TryCatch(tc) => tc
             .try_block
@@ -210,17 +210,17 @@ fn resolve_column_in_statement(
             .iter()
             .chain(tc.catch_block.statements.iter())
             .find_map(|child| {
-                resolve_column_in_statement(child, symbol_table, offset, upper_ident)
+                resolve_column_in_statement(child, symbol_table, offset, ident_text)
             }),
         Statement::Create(create) => match &**create {
             tsql_parser::ast::CreateStatement::Procedure(proc) => {
                 proc.body.iter().find_map(|child| {
-                    resolve_column_in_statement(child, symbol_table, offset, upper_ident)
+                    resolve_column_in_statement(child, symbol_table, offset, ident_text)
                 })
             }
             tsql_parser::ast::CreateStatement::Trigger(trigger) => {
                 trigger.body.iter().find_map(|child| {
-                    resolve_column_in_statement(child, symbol_table, offset, upper_ident)
+                    resolve_column_in_statement(child, symbol_table, offset, ident_text)
                 })
             }
             _ => None,

--- a/crates/ase-ls-core/src/hover.rs
+++ b/crates/ase-ls-core/src/hover.rs
@@ -84,7 +84,7 @@ fn format_column_hover(col: &crate::symbol_table::ColumnSymbol, table_name: &str
 
 /// Check whether `offset` falls within `[span_start, span_end]`.
 /// When `span_end <= span_start` (broken span), uses a fallback window.
-fn in_span(offset: usize, span_start: usize, span_end: u32) -> bool {
+const fn in_span(offset: usize, span_start: usize, span_end: u32) -> bool {
     let span_end = if span_end as usize > span_start {
         span_end as usize
     } else {
@@ -152,9 +152,10 @@ fn resolve_column_in_statement(
             }
 
             // Check inserted columns
-            if let Some(tbl) =
-                crate::symbol_table::SymbolTableBuilder::find_table(symbol_table, &insert.table.name)
-            {
+            if let Some(tbl) = crate::symbol_table::SymbolTableBuilder::find_table(
+                symbol_table,
+                &insert.table.name,
+            ) {
                 for col in &tbl.columns {
                     if col.name.eq_ignore_ascii_case(ident_text) {
                         return Some(format_column_hover(col, &tbl.name));
@@ -190,9 +191,10 @@ fn resolve_column_in_statement(
             }
             None
         }
-        Statement::Block(block) => block.statements.iter().find_map(|child| {
-            resolve_column_in_statement(child, symbol_table, offset, ident_text)
-        }),
+        Statement::Block(block) => block
+            .statements
+            .iter()
+            .find_map(|child| resolve_column_in_statement(child, symbol_table, offset, ident_text)),
         Statement::If(if_stmt) => {
             resolve_column_in_statement(&if_stmt.then_branch, symbol_table, offset, ident_text)
                 .or_else(|| {
@@ -209,9 +211,7 @@ fn resolve_column_in_statement(
             .statements
             .iter()
             .chain(tc.catch_block.statements.iter())
-            .find_map(|child| {
-                resolve_column_in_statement(child, symbol_table, offset, ident_text)
-            }),
+            .find_map(|child| resolve_column_in_statement(child, symbol_table, offset, ident_text)),
         Statement::Create(create) => match &**create {
             tsql_parser::ast::CreateStatement::Procedure(proc) => {
                 proc.body.iter().find_map(|child| {

--- a/crates/ase-ls-core/src/hover.rs
+++ b/crates/ase-ls-core/src/hover.rs
@@ -340,17 +340,19 @@ fn build_schema_hover(
 ///
 /// [`crate::db_docs`] からエントリを検索し、マークダウン形式で返す。
 fn build_hover_content(kind: &TokenKind, text: &str) -> Option<String> {
-    let upper = text.to_uppercase();
-
     match kind {
         TokenKind::LocalVar => Some(format!(
             "```tsql\n{text}: VARIABLE\n```\n\nLocal variable — Declare with `DECLARE {text} TYPE`"
         )),
         _ => {
-            if let Some(entry) = crate::db_docs::lookup(upper.as_str()) {
+            // Fast path: lookup with uppercase conversion. Use entry.name
+            // (already uppercase &'static str) for display to avoid keeping
+            // the allocation when an entry is found.
+            let upper = text.to_uppercase();
+            if let Some(entry) = crate::db_docs::lookup(&upper) {
                 Some(format!(
                     "```tsql\n{}\n```\n\n**`{}`** — {}",
-                    entry.syntax, upper, entry.description
+                    entry.syntax, entry.name, entry.description
                 ))
             } else if kind.is_keyword() {
                 Some(format!("**`{upper}`** — T-SQL Keyword"))

--- a/crates/ase-ls-core/src/lib.rs
+++ b/crates/ase-ls-core/src/lib.rs
@@ -47,6 +47,7 @@ pub use tsql_parser::Parser;
 /// - オブジェクト種別: `TABLE`, `VIEW`, `INDEX`
 ///
 /// `kind.is_keyword()` は残りのキーワードのフォールバックとして機能する。
+#[inline]
 pub(crate) fn token_matches_symbol(
     kind: tsql_token::TokenKind,
     text: &str,

--- a/crates/ase-ls-core/src/line_index.rs
+++ b/crates/ase-ls-core/src/line_index.rs
@@ -29,6 +29,7 @@ impl LineIndex {
 
     /// Convert a byte offset to (line, character), both 0-indexed. O(log n).
     #[must_use]
+    #[inline]
     pub fn offset_to_position(&self, offset: u32) -> (u32, u32) {
         let line = self.line_number(offset);
         let line_start = self.line_offsets[line as usize];
@@ -38,6 +39,7 @@ impl LineIndex {
 
     /// Convert an LSP Position to a byte offset. O(log n) + O(line_length).
     #[must_use]
+    #[inline]
     pub fn position_to_offset(&self, source: &str, position: Position) -> usize {
         let line = position.line as usize;
         if line >= self.line_offsets.len() {
@@ -56,6 +58,7 @@ impl LineIndex {
     }
 
     /// Get the line number for a byte offset using binary search. O(log n).
+    #[inline]
     fn line_number(&self, offset: u32) -> u32 {
         let idx = self.line_offsets.partition_point(|&off| off <= offset);
         (idx as u32).saturating_sub(1)
@@ -69,12 +72,14 @@ impl LineIndex {
 
     /// Get the byte offset of the start of a line. O(1).
     #[must_use]
+    #[inline]
     pub fn line_offset(&self, line: usize) -> usize {
         self.line_offsets.get(line).copied().unwrap_or(0) as usize
     }
 
     /// Convert two byte offsets to an LSP Range. O(log n).
     #[must_use]
+    #[inline]
     pub fn offset_to_range(&self, start_offset: u32, end_offset: u32) -> Range {
         let (start_line, start_char) = self.offset_to_position(start_offset);
         let (end_line, end_char) = self.offset_to_position(end_offset);

--- a/crates/ase-ls-core/src/line_index.rs
+++ b/crates/ase-ls-core/src/line_index.rs
@@ -63,7 +63,7 @@ impl LineIndex {
 
     /// Get the number of lines.
     #[must_use]
-    pub fn line_count(&self) -> usize {
+    pub const fn line_count(&self) -> usize {
         self.line_offsets.len()
     }
 

--- a/crates/ase-ls-core/src/references.rs
+++ b/crates/ase-ls-core/src/references.rs
@@ -50,6 +50,7 @@ pub fn reference_ranges_with_analysis(
 }
 
 /// Check if `haystack` ends with `suffix`, comparing ASCII characters case-insensitively.
+#[inline]
 fn ends_with_ignore_ascii_case(haystack: &str, suffix: &str) -> bool {
     if suffix.len() > haystack.len() {
         return false;

--- a/crates/ase-ls-core/src/references.rs
+++ b/crates/ase-ls-core/src/references.rs
@@ -18,12 +18,8 @@ pub fn reference_ranges_with_analysis(
     position: Position,
     include_declaration: bool,
 ) -> Vec<Range> {
-    let offset = analysis
-        .line_index
-        .position_to_offset(&analysis.source, position);
-
-    let (target_kind, target_text) = match analysis.find_token_at(offset) {
-        Some((t, _)) => (t.kind, t.text.clone()),
+    let (target_kind, target_text) = match analysis.find_token_at_position(position) {
+        Some((t, _)) => (t.kind, &*t.text),
         None => return Vec::new(),
     };
 
@@ -32,7 +28,7 @@ pub fn reference_ranges_with_analysis(
     let mut refs = Vec::new();
 
     for token in &analysis.tokens {
-        if token_matches_symbol(token.kind, &token.text, &target_text, is_var) {
+        if token_matches_symbol(token.kind, &token.text, target_text, is_var) {
             let range = analysis
                 .line_index
                 .offset_to_range(token.span.start, token.span.end);

--- a/crates/ase-ls-core/src/references.rs
+++ b/crates/ase-ls-core/src/references.rs
@@ -12,6 +12,7 @@ use lsp_types::{Position, Range};
 use tsql_token::TokenKind;
 
 /// カーソル位置のシンボルの全参照箇所を検索する（DocumentAnalysis利用）
+#[must_use]
 pub fn reference_ranges_with_analysis(
     analysis: &DocumentAnalysis,
     position: Position,

--- a/crates/ase-ls-core/src/references.rs
+++ b/crates/ase-ls-core/src/references.rs
@@ -224,4 +224,14 @@ mod tests {
             true
         ));
     }
+
+    #[test]
+    fn test_ends_with_ignore_ascii_case() {
+        assert!(ends_with_ignore_ascii_case("CREATE TABLE", "TABLE"));
+        assert!(ends_with_ignore_ascii_case("create table", "TABLE"));
+        assert!(ends_with_ignore_ascii_case("CREATE table", "CREATE TABLE"));
+        assert!(!ends_with_ignore_ascii_case("CREATE", "CREATE TABLE"));
+        assert!(ends_with_ignore_ascii_case("DECLARE", "DECLARE"));
+        assert!(!ends_with_ignore_ascii_case("DECLARE @x", "DECLARE"));
+    }
 }

--- a/crates/ase-ls-core/src/rename.rs
+++ b/crates/ase-ls-core/src/rename.rs
@@ -76,7 +76,7 @@ pub fn get_rename_placeholder_with_analysis(
         .line_index
         .position_to_offset(&analysis.source, position);
     let (token, _) = analysis.find_token_at(offset)?;
-    Some(token.text.clone())
+    Some(token.text.to_string())
 }
 
 /// カーソル位置がリネーム可能か検証する（DocumentAnalysis利用）
@@ -107,7 +107,7 @@ pub fn prepare_rename_with_analysis(
         range: analysis
             .line_index
             .offset_to_range(token.span.start, token.span.end),
-        placeholder: token.text.clone(),
+        placeholder: token.text.to_string(),
     })
 }
 

--- a/crates/ase-ls-core/src/rename.rs
+++ b/crates/ase-ls-core/src/rename.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use tsql_token::TokenKind;
 
 /// カーソル位置のシンボルをリネームする（DocumentAnalysis利用）
+#[must_use]
 pub fn rename_with_analysis(
     analysis: &DocumentAnalysis,
     position: Position,
@@ -66,6 +67,7 @@ pub fn rename_with_analysis(
 }
 
 /// リネームプレースホルダーを取得する（DocumentAnalysis利用）
+#[must_use]
 pub fn get_rename_placeholder_with_analysis(
     analysis: &DocumentAnalysis,
     position: Position,
@@ -81,6 +83,7 @@ pub fn get_rename_placeholder_with_analysis(
 ///
 /// リネーム可能なトークン種別のみ許可し、キーワード・文字列・空白は拒否する。
 /// prepareRename LSPリクエストのハンドラとして使用する。
+#[must_use]
 pub fn prepare_rename_with_analysis(
     analysis: &DocumentAnalysis,
     position: Position,

--- a/crates/ase-ls-core/src/rename.rs
+++ b/crates/ase-ls-core/src/rename.rs
@@ -19,12 +19,8 @@ pub fn rename_with_analysis(
     new_name: &str,
     uri: &Url,
 ) -> Option<WorkspaceEdit> {
-    let offset = analysis
-        .line_index
-        .position_to_offset(&analysis.source, position);
-
-    let (target_kind, target_text) = match analysis.find_token_at(offset) {
-        Some((t, _)) => (t.kind, t.text.clone()),
+    let (target_kind, target_text) = match analysis.find_token_at_position(position) {
+        Some((t, _)) => (t.kind, &*t.text),
         None => return None,
     };
 
@@ -40,7 +36,7 @@ pub fn rename_with_analysis(
     let mut edits = Vec::new();
 
     for token in &analysis.tokens {
-        if token_matches_symbol(token.kind, &token.text, &target_text, is_var) {
+        if token_matches_symbol(token.kind, &token.text, target_text, is_var) {
             edits.push(TextEdit {
                 range: analysis
                     .line_index
@@ -72,10 +68,7 @@ pub fn get_rename_placeholder_with_analysis(
     analysis: &DocumentAnalysis,
     position: Position,
 ) -> Option<String> {
-    let offset = analysis
-        .line_index
-        .position_to_offset(&analysis.source, position);
-    let (token, _) = analysis.find_token_at(offset)?;
+    let (token, _) = analysis.find_token_at_position(position)?;
     Some(token.text.to_string())
 }
 
@@ -88,11 +81,7 @@ pub fn prepare_rename_with_analysis(
     analysis: &DocumentAnalysis,
     position: Position,
 ) -> Option<PrepareRenameResponse> {
-    let offset = analysis
-        .line_index
-        .position_to_offset(&analysis.source, position);
-
-    let (token, _) = analysis.find_token_at(offset)?;
+    let (token, _) = analysis.find_token_at_position(position)?;
 
     let is_renamable = matches!(
         token.kind,

--- a/crates/ase-ls-core/src/semantic_tokens.rs
+++ b/crates/ase-ls-core/src/semantic_tokens.rs
@@ -31,7 +31,7 @@ pub fn semantic_tokens_legend() -> SemanticTokensLegend {
 }
 
 /// TokenKind → セマンティックトークンタイプインデックスのマッピング
-fn token_kind_to_type_index(kind: TokenKind) -> Option<u32> {
+const fn token_kind_to_type_index(kind: TokenKind) -> Option<u32> {
     match kind {
         // キーワード (0)
         _ if kind.is_keyword() => Some(0),

--- a/crates/ase-ls-core/src/semantic_tokens.rs
+++ b/crates/ase-ls-core/src/semantic_tokens.rs
@@ -383,4 +383,69 @@ mod tests {
         };
         assert!(tokens.data.is_empty());
     }
+
+    #[test]
+    fn test_variable_gets_variable_token() {
+        let source = "DECLARE @count INT\nSET @count = 1";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let result = semantic_tokens_full_with_analysis(&analysis);
+        let tokens = match result {
+            SemanticTokensResult::Tokens(t) => t,
+            _ => panic!("Expected Tokens"),
+        };
+        // VARIABLE = index 6 (see semantic_tokens_legend)
+        assert!(
+            tokens.data.iter().any(|t| t.token_type == 6),
+            "Local variable @count should get VARIABLE semantic token (type 6)"
+        );
+    }
+
+    #[test]
+    fn test_datatype_gets_type_token() {
+        let source = "DECLARE @x INT";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let result = semantic_tokens_full_with_analysis(&analysis);
+        let tokens = match result {
+            SemanticTokensResult::Tokens(t) => t,
+            _ => panic!("Expected Tokens"),
+        };
+        // TYPE = index 1 (see semantic_tokens_legend)
+        assert!(
+            tokens.data.iter().any(|t| t.token_type == 1),
+            "INT data type should get TYPE semantic token (type 1)"
+        );
+    }
+
+    #[test]
+    fn test_range_tokens_intersecting_boundary() {
+        use lsp_types::{Position, Range as LspRange};
+        let source = "SELECT * FROM t WHERE id = 1";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        // Range covering FROM and t (char 9-15)
+        let range = LspRange {
+            start: Position {
+                line: 0,
+                character: 9,
+            },
+            end: Position {
+                line: 0,
+                character: 16,
+            },
+        };
+        let result = semantic_tokens_range_with_analysis(&analysis, range);
+        let tokens = match result {
+            SemanticTokensRangeResult::Tokens(t) => t,
+            _ => panic!("Expected Tokens"),
+        };
+        // Should include FROM keyword token and identifier t
+        assert!(
+            !tokens.data.is_empty(),
+            "FROM and t should be in the range"
+        );
+        // At least one keyword (FROM) and optionally one identifier
+        assert!(
+            tokens.data.iter().any(|t| t.token_type == 0),
+            "FROM keyword should get KEYWORD token in range"
+        );
+    }
 }

--- a/crates/ase-ls-core/src/semantic_tokens.rs
+++ b/crates/ase-ls-core/src/semantic_tokens.rs
@@ -352,4 +352,48 @@ mod tests {
         };
         assert!(tokens.data.is_empty());
     }
+
+    #[test]
+    fn test_view_name_gets_class_token() {
+        let source = "CREATE VIEW my_view AS SELECT 1";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let result = semantic_tokens_full_with_analysis(&analysis);
+        let tokens = match result {
+            SemanticTokensResult::Tokens(t) => t,
+            _ => panic!("Expected Tokens"),
+        };
+        // "my_view" should get CLASS token (index 9)
+        assert!(
+            tokens.data.iter().any(|t| t.token_type == 9),
+            "View name should get CLASS semantic token"
+        );
+    }
+
+    #[test]
+    fn test_keyword_tokens_present() {
+        let source = "SELECT * FROM t";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let result = semantic_tokens_full_with_analysis(&analysis);
+        let tokens = match result {
+            SemanticTokensResult::Tokens(t) => t,
+            _ => panic!("Expected Tokens"),
+        };
+        // SELECT and FROM should be keyword tokens (type 0)
+        assert!(
+            tokens.data.iter().any(|t| t.token_type == 0),
+            "Keywords should get KEYWORD semantic token"
+        );
+    }
+
+    #[test]
+    fn test_empty_source_no_tokens() {
+        let source = "";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let result = semantic_tokens_full_with_analysis(&analysis);
+        let tokens = match result {
+            SemanticTokensResult::Tokens(t) => t,
+            _ => panic!("Expected Tokens"),
+        };
+        assert!(tokens.data.is_empty());
+    }
 }

--- a/crates/ase-ls-core/src/semantic_tokens.rs
+++ b/crates/ase-ls-core/src/semantic_tokens.rs
@@ -109,47 +109,71 @@ const fn token_kind_to_type_index(kind: TokenKind) -> Option<u32> {
     }
 }
 
-/// Resolve an identifier token's semantic type using the symbol table.
-fn resolve_ident_type(analysis: &DocumentAnalysis, text: &str) -> Option<u32> {
-    analysis.symbol_table.resolve_semantic_type(text)
+/// Resolve a token's semantic type index, handling both direct kinds and symbol-table identifiers.
+#[inline]
+fn resolve_token_type(analysis: &DocumentAnalysis, kind: TokenKind, text: &str) -> Option<u32> {
+    token_kind_to_type_index(kind).or_else(|| {
+        if kind == TokenKind::Ident {
+            analysis.symbol_table.resolve_semantic_type(text)
+        } else {
+            None
+        }
+    })
+}
+
+/// Accumulator for LSP semantic token delta encoding.
+struct DeltaEncoder {
+    prev_line: u32,
+    prev_char: u32,
+}
+
+impl DeltaEncoder {
+    const fn new() -> Self {
+        Self {
+            prev_line: 0,
+            prev_char: 0,
+        }
+    }
+
+    /// Push a delta-encoded semantic token.
+    fn push(
+        &mut self,
+        tokens: &mut Vec<SemanticToken>,
+        line: u32,
+        character: u32,
+        length: u32,
+        token_type: u32,
+    ) {
+        let delta_line = line.saturating_sub(self.prev_line);
+        let delta_start = if delta_line == 0 {
+            character.saturating_sub(self.prev_char)
+        } else {
+            character
+        };
+
+        tokens.push(SemanticToken {
+            delta_line,
+            delta_start,
+            length,
+            token_type,
+            token_modifiers_bitset: 0,
+        });
+
+        self.prev_line = line;
+        self.prev_char = character;
+    }
 }
 
 /// ソースコードから Semantic Tokens を生成する（DocumentAnalysis利用）
 #[must_use]
 pub fn semantic_tokens_full_with_analysis(analysis: &DocumentAnalysis) -> SemanticTokensResult {
     let mut tokens = Vec::new();
-    let mut prev_line = 0u32;
-    let mut prev_char = 0u32;
+    let mut encoder = DeltaEncoder::new();
 
     for token in &analysis.tokens {
-        let type_idx = token_kind_to_type_index(token.kind).or_else(|| {
-            if token.kind == TokenKind::Ident {
-                resolve_ident_type(analysis, &token.text)
-            } else {
-                None
-            }
-        });
-
-        if let Some(type_idx) = type_idx {
+        if let Some(type_idx) = resolve_token_type(analysis, token.kind, &token.text) {
             let (line, character) = analysis.line_index.offset_to_position(token.span.start);
-
-            let delta_line = line.saturating_sub(prev_line);
-            let delta_start = if delta_line == 0 {
-                character.saturating_sub(prev_char)
-            } else {
-                character
-            };
-
-            tokens.push(SemanticToken {
-                delta_line,
-                delta_start,
-                length: token.span.len(),
-                token_type: type_idx,
-                token_modifiers_bitset: 0,
-            });
-
-            prev_line = line;
-            prev_char = character;
+            encoder.push(&mut tokens, line, character, token.span.len(), type_idx);
         }
     }
 
@@ -168,8 +192,7 @@ pub fn semantic_tokens_range_with_analysis(
     range: Range,
 ) -> SemanticTokensRangeResult {
     let mut tokens = Vec::new();
-    let mut prev_line = 0u32;
-    let mut prev_char = 0u32;
+    let mut encoder = DeltaEncoder::new();
 
     for token in &analysis.tokens {
         let (line, character) = analysis.line_index.offset_to_position(token.span.start);
@@ -185,32 +208,8 @@ pub fn semantic_tokens_range_with_analysis(
             break;
         }
 
-        let type_idx = token_kind_to_type_index(token.kind).or_else(|| {
-            if token.kind == TokenKind::Ident {
-                resolve_ident_type(analysis, &token.text)
-            } else {
-                None
-            }
-        });
-
-        if let Some(type_idx) = type_idx {
-            let delta_line = line.saturating_sub(prev_line);
-            let delta_start = if delta_line == 0 {
-                character.saturating_sub(prev_char)
-            } else {
-                character
-            };
-
-            tokens.push(SemanticToken {
-                delta_line,
-                delta_start,
-                length: token.span.len(),
-                token_type: type_idx,
-                token_modifiers_bitset: 0,
-            });
-
-            prev_line = line;
-            prev_char = character;
+        if let Some(type_idx) = resolve_token_type(analysis, token.kind, &token.text) {
+            encoder.push(&mut tokens, line, character, token.span.len(), type_idx);
         }
     }
 
@@ -438,10 +437,7 @@ mod tests {
             _ => panic!("Expected Tokens"),
         };
         // Should include FROM keyword token and identifier t
-        assert!(
-            !tokens.data.is_empty(),
-            "FROM and t should be in the range"
-        );
+        assert!(!tokens.data.is_empty(), "FROM and t should be in the range");
         // At least one keyword (FROM) and optionally one identifier
         assert!(
             tokens.data.iter().any(|t| t.token_type == 0),

--- a/crates/ase-ls-core/src/semantic_tokens.rs
+++ b/crates/ase-ls-core/src/semantic_tokens.rs
@@ -111,20 +111,7 @@ fn token_kind_to_type_index(kind: TokenKind) -> Option<u32> {
 
 /// Resolve an identifier token's semantic type using the symbol table.
 fn resolve_ident_type(analysis: &DocumentAnalysis, text: &str) -> Option<u32> {
-    let upper = text.to_uppercase();
-    if analysis.symbol_table.tables.contains_key(&upper) {
-        return Some(9); // CLASS
-    }
-    if analysis.symbol_table.procedures.contains_key(&upper) {
-        return Some(2); // FUNCTION
-    }
-    if analysis.symbol_table.views.contains_key(&upper) {
-        return Some(9); // CLASS — views are table-like
-    }
-    if analysis.symbol_table.indexes.contains_key(&upper) {
-        return Some(9); // CLASS — indexes are objects
-    }
-    None
+    analysis.symbol_table.resolve_semantic_type(text)
 }
 
 /// ソースコードから Semantic Tokens を生成する（DocumentAnalysis利用）

--- a/crates/ase-ls-core/src/signature_help.rs
+++ b/crates/ase-ls-core/src/signature_help.rs
@@ -101,6 +101,7 @@ fn scan_for_call_frame<'a>(
 }
 
 /// SignatureHelp情報を生成する（DocumentAnalysis利用）
+#[must_use]
 pub fn signature_help_with_analysis(
     analysis: &DocumentAnalysis,
     position: Position,

--- a/crates/ase-ls-core/src/signature_help.rs
+++ b/crates/ase-ls-core/src/signature_help.rs
@@ -34,8 +34,10 @@ fn scan_for_call_frame<'a>(
 ) -> Option<CallFrame> {
     let mut stack: Vec<CallFrame> = Vec::new();
     let mut paren_depth = 0i32;
-    // LParen の前に Ident/Keyword があった場合、その名前を保留する
-    let mut pending_name: Option<String> = None;
+    // LParen の前に Ident/Keyword があった場合、その名前を借用で保留する。
+    // .to_uppercase() は CallFrame プッシュ時のみ実行し、
+    // 関数呼び出しに続かないトークンでの不要なアロケーションを回避する。
+    let mut pending_name: Option<&'a str> = None;
 
     for (kind, text, span_start) in tokens {
         if span_start > offset {
@@ -43,21 +45,19 @@ fn scan_for_call_frame<'a>(
         }
 
         match kind {
-            TokenKind::Ident => {
-                pending_name = Some(text.to_uppercase());
+            TokenKind::Ident | TokenKind::LocalVar => {
+                pending_name = Some(text);
             }
             TokenKind::LParen => {
                 paren_depth += 1;
                 if let Some(name) = pending_name.take() {
                     stack.push(CallFrame {
-                        func_name: name,
+                        func_name: name.to_uppercase(),
                         active_param: 0,
                         open_depth: paren_depth,
                     });
-                } else {
-                    // 関数名なしの '(' — 純粋なグループ化
-                    pending_name = None;
                 }
+                // 関数名なしの '(' — 純粋なグループ化
             }
             TokenKind::RParen => {
                 paren_depth -= 1;
@@ -86,7 +86,7 @@ fn scan_for_call_frame<'a>(
             _ => {
                 // キーワードトークンも関数名候補として扱う
                 if kind.is_keyword() {
-                    pending_name = Some(text.to_uppercase());
+                    pending_name = Some(text);
                 }
             }
         }

--- a/crates/ase-ls-core/src/signature_help.rs
+++ b/crates/ase-ls-core/src/signature_help.rs
@@ -290,4 +290,67 @@ mod tests {
         let sig = result.unwrap();
         assert_eq!(sig.signatures[0].active_parameter, Some(2));
     }
+
+    #[test]
+    fn test_signature_help_empty_source() {
+        let analysis = crate::analysis::DocumentAnalysis::new("");
+        let result = signature_help_with_analysis(
+            &analysis,
+            Position {
+                line: 0,
+                character: 0,
+            },
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_signature_help_cursor_after_closing_paren() {
+        let source = "SELECT SUBSTRING(col, 1, 3) FROM t";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        // Cursor after the closing paren
+        let result = signature_help_with_analysis(
+            &analysis,
+            Position {
+                line: 0,
+                character: 30,
+            },
+        );
+        assert!(
+            result.is_none(),
+            "Should not show signature help outside function call"
+        );
+    }
+
+    #[test]
+    fn test_signature_help_nested_parens_not_function() {
+        let source = "SELECT (1 + 2) FROM t";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        let result = signature_help_with_analysis(
+            &analysis,
+            Position {
+                line: 0,
+                character: 10,
+            },
+        );
+        // Pure grouping parens without a function name → no help
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_signature_help_multiline_function() {
+        let source = "SELECT SUBSTRING(\n  col,\n  1,\n  3\n) FROM t";
+        let analysis = crate::analysis::DocumentAnalysis::new(source);
+        // Cursor on 3rd param (line 3, char 2)
+        let result = signature_help_with_analysis(
+            &analysis,
+            Position {
+                line: 3,
+                character: 2,
+            },
+        );
+        assert!(result.is_some());
+        let sig = result.unwrap();
+        assert_eq!(sig.signatures[0].active_parameter, Some(2));
+    }
 }

--- a/crates/ase-ls-core/src/signature_help.rs
+++ b/crates/ase-ls-core/src/signature_help.rs
@@ -114,7 +114,7 @@ pub fn signature_help_with_analysis(
         analysis
             .tokens
             .iter()
-            .map(|t| (t.kind, t.text.as_str(), t.span.start as usize)),
+            .map(|t| (t.kind, &*t.text, t.span.start as usize)),
         offset,
     )?;
 

--- a/crates/ase-ls-core/src/symbol_table/mod.rs
+++ b/crates/ase-ls-core/src/symbol_table/mod.rs
@@ -6,7 +6,7 @@
 //! - ビュー定義（CREATE VIEW）とインデックス定義（CREATE INDEX）を抽出
 //! - 変数宣言（DECLARE）から変数情報を抽出
 
-use lsp_types::{Position, Range};
+use lsp_types::Range;
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use tsql_parser::ast::{CreateStatement, DataType, DeclareStatement, Statement};
@@ -77,6 +77,7 @@ impl SymbolTable {
     ///
     /// Uses a single `CaseInsensitiveKey` allocation to check all maps.
     #[must_use]
+    #[inline]
     pub fn resolve_semantic_type(&self, name: &str) -> Option<u32> {
         let key = CaseInsensitiveKey::new(name);
         if self.tables.contains_key(&key)
@@ -236,6 +237,7 @@ pub struct SymbolTableBuilder;
 
 impl SymbolTableBuilder {
     /// ソースコードからシンボルテーブルを構築する
+    #[must_use]
     pub fn build(source: &str) -> SymbolTable {
         let mut table = SymbolTable::default();
         let line_index = LineIndex::new(source);
@@ -253,6 +255,7 @@ impl SymbolTableBuilder {
     }
 
     /// ソースコードからシンボルテーブルを構築（エラー許容）
+    #[must_use]
     pub fn build_tolerant(source: &str) -> SymbolTable {
         let mut table = SymbolTable::default();
         let line_index = LineIndex::new(source);
@@ -529,6 +532,7 @@ impl SymbolTableBuilder {
 
     /// テーブル名でテーブルを検索 (case-insensitive)
     #[must_use]
+    #[inline]
     pub fn find_table<'a>(table: &'a SymbolTable, name: &str) -> Option<&'a TableSymbol> {
         let key = CaseInsensitiveKey::new(name);
         table.tables.get::<str>(key.borrow())
@@ -536,6 +540,7 @@ impl SymbolTableBuilder {
 
     /// プロシージャ名でプロシージャを検索 (case-insensitive)
     #[must_use]
+    #[inline]
     pub fn find_procedure<'a>(table: &'a SymbolTable, name: &str) -> Option<&'a ProcedureSymbol> {
         let key = CaseInsensitiveKey::new(name);
         table.procedures.get::<str>(key.borrow())
@@ -543,6 +548,7 @@ impl SymbolTableBuilder {
 
     /// ビュー名でビューを検索 (case-insensitive)
     #[must_use]
+    #[inline]
     pub fn find_view<'a>(table: &'a SymbolTable, name: &str) -> Option<&'a ViewSymbol> {
         let key = CaseInsensitiveKey::new(name);
         table.views.get::<str>(key.borrow())
@@ -550,6 +556,7 @@ impl SymbolTableBuilder {
 
     /// インデックス名でインデックスを検索 (case-insensitive)
     #[must_use]
+    #[inline]
     pub fn find_index<'a>(table: &'a SymbolTable, name: &str) -> Option<&'a IndexSymbol> {
         let key = CaseInsensitiveKey::new(name);
         table.indexes.get::<str>(key.borrow())
@@ -557,6 +564,7 @@ impl SymbolTableBuilder {
 
     /// トリガー名でトリガーを検索 (case-insensitive)
     #[must_use]
+    #[inline]
     pub fn find_trigger<'a>(table: &'a SymbolTable, name: &str) -> Option<&'a TriggerSymbol> {
         let key = CaseInsensitiveKey::new(name);
         table.triggers.get::<str>(key.borrow())
@@ -564,6 +572,7 @@ impl SymbolTableBuilder {
 
     /// 変数名で変数を検索 (case-insensitive, @prefix auto-added)
     #[must_use]
+    #[inline]
     pub fn find_variable<'a>(table: &'a SymbolTable, name: &str) -> Option<&'a VariableSymbol> {
         let search_name = if name.starts_with('@') {
             CaseInsensitiveKey::new(name)
@@ -571,40 +580,6 @@ impl SymbolTableBuilder {
             CaseInsensitiveKey::new(&format!("@{}", name))
         };
         table.variables.get::<str>(search_name.borrow())
-    }
-
-    /// カーソル位置の識別子を特定
-    pub fn find_identifier_at(
-        source: &str,
-        position: Position,
-    ) -> Option<(String, lsp_types::Range)> {
-        let line_index = LineIndex::new(source);
-        let offset = line_index.position_to_offset(source, position);
-
-        for token_result in tsql_lexer::Lexer::new(source) {
-            let token = match token_result {
-                Ok(t) => t,
-                Err(_) => continue,
-            };
-            let start = token.span.start as usize;
-            let end = token.span.end as usize;
-            if offset >= start && offset < end {
-                if matches!(
-                    token.kind,
-                    tsql_token::TokenKind::Ident | tsql_token::TokenKind::LocalVar
-                ) {
-                    return Some((
-                        token.text.to_string(),
-                        span_to_range(&line_index, token.span),
-                    ));
-                }
-                return None;
-            }
-            if start > offset {
-                break;
-            }
-        }
-        None
     }
 }
 
@@ -619,6 +594,7 @@ fn span_to_range(line_index: &LineIndex, span: Span) -> Range {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use lsp_types::Position;
 
     #[test]
     fn test_case_insensitive_key_equality() {
@@ -784,21 +760,6 @@ mod tests {
         assert!(table.tables.is_empty());
         assert!(table.procedures.is_empty());
         assert!(table.views.is_empty());
-    }
-
-    #[test]
-    fn test_find_identifier_at() {
-        let source = "SELECT * FROM users";
-        let result = SymbolTableBuilder::find_identifier_at(
-            source,
-            Position {
-                line: 0,
-                character: 15,
-            },
-        );
-        assert!(result.is_some());
-        let (name, _range) = result.unwrap();
-        assert_eq!(name, "users");
     }
 
     // --- Explicit variant coverage tests (#56) ---

--- a/crates/ase-ls-core/src/symbol_table/mod.rs
+++ b/crates/ase-ls-core/src/symbol_table/mod.rs
@@ -68,6 +68,30 @@ pub struct SymbolTable {
     pub variables: HashMap<CaseInsensitiveKey, VariableSymbol>,
 }
 
+impl SymbolTable {
+    /// Resolve the semantic token type for an identifier name.
+    ///
+    /// Returns `Some(9)` (CLASS) for tables, views, and indexes,
+    /// `Some(2)` (FUNCTION) for procedures,
+    /// or `None` if the name is not a known object.
+    ///
+    /// Uses a single `CaseInsensitiveKey` allocation to check all maps.
+    #[must_use]
+    pub fn resolve_semantic_type(&self, name: &str) -> Option<u32> {
+        let key = CaseInsensitiveKey::new(name);
+        if self.tables.contains_key(&key)
+            || self.views.contains_key(&key)
+            || self.indexes.contains_key(&key)
+        {
+            return Some(9); // CLASS
+        }
+        if self.procedures.contains_key(&key) {
+            return Some(2); // FUNCTION
+        }
+        None
+    }
+}
+
 /// Table symbol extracted from `CREATE TABLE`.
 #[derive(Debug, Clone)]
 pub struct TableSymbol {
@@ -515,6 +539,27 @@ impl SymbolTableBuilder {
     pub fn find_procedure<'a>(table: &'a SymbolTable, name: &str) -> Option<&'a ProcedureSymbol> {
         let key = CaseInsensitiveKey::new(name);
         table.procedures.get::<str>(key.borrow())
+    }
+
+    /// ビュー名でビューを検索 (case-insensitive)
+    #[must_use]
+    pub fn find_view<'a>(table: &'a SymbolTable, name: &str) -> Option<&'a ViewSymbol> {
+        let key = CaseInsensitiveKey::new(name);
+        table.views.get::<str>(key.borrow())
+    }
+
+    /// インデックス名でインデックスを検索 (case-insensitive)
+    #[must_use]
+    pub fn find_index<'a>(table: &'a SymbolTable, name: &str) -> Option<&'a IndexSymbol> {
+        let key = CaseInsensitiveKey::new(name);
+        table.indexes.get::<str>(key.borrow())
+    }
+
+    /// トリガー名でトリガーを検索 (case-insensitive)
+    #[must_use]
+    pub fn find_trigger<'a>(table: &'a SymbolTable, name: &str) -> Option<&'a TriggerSymbol> {
+        let key = CaseInsensitiveKey::new(name);
+        table.triggers.get::<str>(key.borrow())
     }
 
     /// 変数名で変数を検索 (case-insensitive, @prefix auto-added)

--- a/crates/ase-ls-core/src/symbol_table/mod.rs
+++ b/crates/ase-ls-core/src/symbol_table/mod.rs
@@ -947,4 +947,142 @@ mod tests {
             "Go to Definition should find trigger definition"
         );
     }
+
+    // --- find_* helper tests ---
+
+    #[test]
+    fn test_find_view() {
+        let source = "CREATE VIEW active_users AS SELECT * FROM users";
+        let table = SymbolTableBuilder::build(source);
+        assert!(
+            SymbolTableBuilder::find_view(&table, "active_users").is_some(),
+            "Should find view with original case"
+        );
+        assert!(
+            SymbolTableBuilder::find_view(&table, "ACTIVE_USERS").is_some(),
+            "Should find view with uppercase"
+        );
+        assert!(
+            SymbolTableBuilder::find_view(&table, "Active_Users").is_some(),
+            "Should find view with mixed case"
+        );
+        assert!(
+            SymbolTableBuilder::find_view(&table, "nonexistent").is_none(),
+            "Should not find nonexistent view"
+        );
+    }
+
+    #[test]
+    fn test_find_index() {
+        let source = "CREATE INDEX idx_name ON users (id)";
+        let table = SymbolTableBuilder::build(source);
+        assert!(
+            SymbolTableBuilder::find_index(&table, "idx_name").is_some(),
+            "Should find index with original case"
+        );
+        assert!(
+            SymbolTableBuilder::find_index(&table, "IDX_NAME").is_some(),
+            "Should find index with uppercase"
+        );
+        assert!(
+            SymbolTableBuilder::find_index(&table, "nonexistent").is_none(),
+            "Should not find nonexistent index"
+        );
+        let idx = SymbolTableBuilder::find_index(&table, "IDX_NAME").expect("found");
+        assert_eq!(idx.columns, vec!["id"]);
+    }
+
+    #[test]
+    fn test_find_trigger() {
+        let source = "CREATE TRIGGER tr_test ON users FOR INSERT AS BEGIN SELECT 1 END";
+        let table = SymbolTableBuilder::build(source);
+        assert!(
+            SymbolTableBuilder::find_trigger(&table, "tr_test").is_some(),
+            "Should find trigger with original case"
+        );
+        assert!(
+            SymbolTableBuilder::find_trigger(&table, "TR_TEST").is_some(),
+            "Should find trigger with uppercase"
+        );
+        assert!(
+            SymbolTableBuilder::find_trigger(&table, "nonexistent").is_none(),
+            "Should not find nonexistent trigger"
+        );
+        let trigger = SymbolTableBuilder::find_trigger(&table, "TR_TEST").expect("found");
+        assert_eq!(trigger.table_name, "users");
+    }
+
+    #[test]
+    fn test_find_index_unique() {
+        let source = "CREATE UNIQUE INDEX idx_unique_email ON users (email)";
+        let table = SymbolTableBuilder::build_tolerant(source);
+        let idx = SymbolTableBuilder::find_index(&table, "idx_unique_email").expect("found");
+        assert!(idx.is_unique, "Should detect UNIQUE index");
+    }
+
+    // --- resolve_semantic_type tests ---
+
+    #[test]
+    fn test_resolve_semantic_type_table() {
+        let source = "CREATE TABLE users (id INT)";
+        let table = SymbolTableBuilder::build(source);
+        assert_eq!(
+            table.resolve_semantic_type("users"),
+            Some(9),
+            "Table should resolve to CLASS (9)"
+        );
+    }
+
+    #[test]
+    fn test_resolve_semantic_type_procedure() {
+        let source = "CREATE PROCEDURE my_proc AS BEGIN RETURN 1 END";
+        let table = SymbolTableBuilder::build(source);
+        assert_eq!(
+            table.resolve_semantic_type("my_proc"),
+            Some(2),
+            "Procedure should resolve to FUNCTION (2)"
+        );
+    }
+
+    #[test]
+    fn test_resolve_semantic_type_view() {
+        let source = "CREATE VIEW my_view AS SELECT 1";
+        let table = SymbolTableBuilder::build(source);
+        assert_eq!(
+            table.resolve_semantic_type("my_view"),
+            Some(9),
+            "View should resolve to CLASS (9)"
+        );
+    }
+
+    #[test]
+    fn test_resolve_semantic_type_index() {
+        let source = "CREATE INDEX idx_name ON users (id)";
+        let table = SymbolTableBuilder::build(source);
+        assert_eq!(
+            table.resolve_semantic_type("idx_name"),
+            Some(9),
+            "Index should resolve to CLASS (9)"
+        );
+    }
+
+    #[test]
+    fn test_resolve_semantic_type_unknown() {
+        let source = "CREATE TABLE users (id INT)";
+        let table = SymbolTableBuilder::build(source);
+        assert_eq!(
+            table.resolve_semantic_type("nonexistent"),
+            None,
+            "Unknown name should resolve to None"
+        );
+    }
+
+    #[test]
+    fn test_resolve_semantic_type_case_insensitive() {
+        let source = "CREATE TABLE MyTable (id INT)";
+        let table = SymbolTableBuilder::build(source);
+        assert_eq!(table.resolve_semantic_type("mytable"), Some(9));
+        assert_eq!(table.resolve_semantic_type("MYTABLE"), Some(9));
+        assert_eq!(table.resolve_semantic_type("MyTable"), Some(9));
+    }
 }

--- a/crates/ase-ls-core/src/symbol_table/mod.rs
+++ b/crates/ase-ls-core/src/symbol_table/mod.rs
@@ -577,7 +577,7 @@ impl SymbolTableBuilder {
         let search_name = if name.starts_with('@') {
             CaseInsensitiveKey::new(name)
         } else {
-            CaseInsensitiveKey::new(&format!("@{}", name))
+            CaseInsensitiveKey::new(&format!("@{name}"))
         };
         table.variables.get::<str>(search_name.borrow())
     }

--- a/crates/ase-ls-core/src/symbols.rs
+++ b/crates/ase-ls-core/src/symbols.rs
@@ -8,6 +8,7 @@ use lsp_types::{DocumentSymbol, DocumentSymbolResponse, SymbolKind};
 use tsql_parser::ast::{Statement, TableReference};
 
 /// DocumentAnalysisから Document Symbols を生成する（キャッシュ利用）
+#[must_use]
 pub fn document_symbols_with_analysis(
     analysis: &DocumentAnalysis,
 ) -> Option<DocumentSymbolResponse> {

--- a/crates/ase-ls-core/src/symbols.rs
+++ b/crates/ase-ls-core/src/symbols.rs
@@ -100,7 +100,7 @@ fn table_ref_name(tr: &TableReference) -> String {
 
 /// DocumentSymbol を構築するヘルパー
 #[allow(deprecated)]
-fn make_symbol(name: String, kind: SymbolKind, range: lsp_types::Range) -> DocumentSymbol {
+const fn make_symbol(name: String, kind: SymbolKind, range: lsp_types::Range) -> DocumentSymbol {
     DocumentSymbol {
         name,
         kind,

--- a/crates/ase-ls-core/src/workspace_symbols.rs
+++ b/crates/ase-ls-core/src/workspace_symbols.rs
@@ -59,6 +59,7 @@ fn collect_symbols(
 }
 
 /// DocumentAnalysisからクエリにマッチするシンボルを検索する
+#[must_use]
 pub fn workspace_symbols_with_analysis(
     analysis: &DocumentAnalysis,
     query: &str,

--- a/crates/ase-ls/src/server.rs
+++ b/crates/ase-ls/src/server.rs
@@ -21,8 +21,8 @@ pub struct AseLanguageServer {
 
 /// メモリ上のドキュメント管理
 struct DocumentStore {
-    /// URI → analysis
-    docs: std::collections::HashMap<String, DocumentAnalysis>,
+    /// URI → analysis (Arc で共有、リクエストごとのcloneを回避)
+    docs: std::collections::HashMap<String, Arc<DocumentAnalysis>>,
 }
 
 impl DocumentStore {
@@ -34,7 +34,7 @@ impl DocumentStore {
 
     /// Insert or replace a document's analysis.
     fn upsert(&mut self, uri: &str, text: &str) {
-        let analysis = DocumentAnalysis::new(text);
+        let analysis = Arc::new(DocumentAnalysis::new(text));
         self.docs.insert(uri.to_string(), analysis);
     }
 
@@ -63,7 +63,7 @@ impl AseLanguageServer {
     }
 
     /// URIに対応するDocumentAnalysisを取得する
-    async fn get_analysis(&self, uri: &Url) -> Option<DocumentAnalysis> {
+    async fn get_analysis(&self, uri: &Url) -> Option<Arc<DocumentAnalysis>> {
         let docs = self.documents.read().await;
         docs.docs.get(uri.as_str()).cloned()
     }

--- a/crates/mysql-emitter/src/converters/function.rs
+++ b/crates/mysql-emitter/src/converters/function.rs
@@ -65,7 +65,7 @@ impl FunctionConverter {
                     .collect::<Result<Vec<_>, _>>()?
                     .join(", ");
 
-                return Ok(format!("{}({})", mapped_name, args_str));
+                return Ok(format!("{mapped_name}({args_str})"));
             }
             _ => {
                 // 名前マッピングを試みる
@@ -76,7 +76,7 @@ impl FunctionConverter {
                         .collect::<Result<Vec<_>, _>>()?
                         .join(", ");
 
-                    return Ok(format!("{}({})", mapped, args_str));
+                    return Ok(format!("{mapped}({args_str})"));
                 }
             }
         }
@@ -134,7 +134,7 @@ impl FunctionConverter {
         // datepart の文字列を解析
         let part = Self::convert_datepart(&datepart);
 
-        Ok(format!("DATE_ADD({}, INTERVAL {} {})", date, number, part))
+        Ok(format!("DATE_ADD({date}, INTERVAL {number} {part})"))
     }
 
     /// DATEDIFF を変換
@@ -155,7 +155,7 @@ impl FunctionConverter {
         let start = emitter.visit_expression(&args[1])?;
         let end = emitter.visit_expression(&args[2])?;
 
-        Ok(format!("DATEDIFF({}, {})", end, start))
+        Ok(format!("DATEDIFF({end}, {start})"))
     }
 
     /// T-SQL の datepart を MySQL の interval に変換

--- a/crates/mysql-emitter/src/error.rs
+++ b/crates/mysql-emitter/src/error.rs
@@ -33,16 +33,16 @@ impl fmt::Display for EmitError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UnsupportedStatement { statement_type } => {
-                write!(f, "Unsupported statement type: {}", statement_type)
+                write!(f, "Unsupported statement type: {statement_type}")
             }
             Self::UnsupportedExpression { expression_type } => {
-                write!(f, "Unsupported expression type: {}", expression_type)
+                write!(f, "Unsupported expression type: {expression_type}")
             }
             Self::UnsupportedDataType { data_type } => {
-                write!(f, "Unsupported data type: {}", data_type)
+                write!(f, "Unsupported data type: {data_type}")
             }
             Self::UnsupportedFunction { function_name } => {
-                write!(f, "Unsupported function: {}", function_name)
+                write!(f, "Unsupported function: {function_name}")
             }
         }
     }

--- a/crates/mysql-emitter/src/lib.rs
+++ b/crates/mysql-emitter/src/lib.rs
@@ -173,7 +173,7 @@ impl MySqlEmitter {
                 if i > 0 {
                     self.write(", ");
                 }
-                self.write(&format!("`{}`", col));
+                self.write(&format!("`{col}`"));
             }
             self.write(")");
         }
@@ -444,12 +444,12 @@ impl MySqlEmitter {
                 self.write("*");
             }
             tsql_parser::common::CommonSelectItem::QualifiedWildcard(table) => {
-                self.write(&format!("`{}`.*", table));
+                self.write(&format!("`{table}`.*"));
             }
             tsql_parser::common::CommonSelectItem::Expression(expr, alias) => {
                 self.visit_expression(expr)?;
                 if let Some(a) = alias {
-                    self.write(&format!(" AS `{}`", a));
+                    self.write(&format!(" AS `{a}`"));
                 }
             }
         }
@@ -463,9 +463,9 @@ impl MySqlEmitter {
     ) -> Result<(), EmitError> {
         match table {
             tsql_parser::common::CommonTableReference::Table { name, alias, .. } => {
-                self.write(&format!("`{}`", name));
+                self.write(&format!("`{name}`"));
                 if let Some(a) = alias {
-                    self.write(&format!(" AS `{}`", a));
+                    self.write(&format!(" AS `{a}`"));
                 }
             }
             tsql_parser::common::CommonTableReference::Derived {
@@ -475,7 +475,7 @@ impl MySqlEmitter {
                 self.visit_select_statement(subquery)?;
                 self.write(")");
                 if let Some(a) = alias {
-                    self.write(&format!(" AS `{}`", a));
+                    self.write(&format!(" AS `{a}`"));
                 }
             }
         }
@@ -698,7 +698,7 @@ impl MySqlEmitter {
         // ESCAPE句を出力
         if let Some(esc) = escape {
             let escape_str = self.visit_expression(esc)?;
-            self.write(&format!(" ESCAPE {}", escape_str));
+            self.write(&format!(" ESCAPE {escape_str}"));
         }
 
         Ok(())

--- a/crates/mysql-emitter/tests/emit_test.rs
+++ b/crates/mysql-emitter/tests/emit_test.rs
@@ -1,0 +1,112 @@
+//! MySQL Emitter integration tests
+//!
+//! Common SQL AST → MySQL SQL 変換のテスト。
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+#![allow(clippy::expect_used)]
+
+use mysql_emitter::{EmitterConfig, MySqlEmitter};
+use tsql_parser::{parse, ToCommonAst};
+
+/// SELECT * FROM の基本的な発行テスト
+#[test]
+fn test_emit_select_star() {
+    let sql = "SELECT * FROM users";
+    let statements = parse(sql).unwrap();
+    let common_stmt = statements[0].to_common_ast().unwrap();
+
+    let config = EmitterConfig::default();
+    let mut emitter = MySqlEmitter::new(config);
+    let mysql_sql = emitter.emit(&common_stmt).unwrap();
+
+    // MySQL emitter uses backtick quoting for identifiers
+    assert!(mysql_sql.contains("SELECT *"));
+    assert!(mysql_sql.contains("users"));
+}
+
+/// WHERE句付きSELECTの発行テスト
+#[test]
+fn test_emit_select_with_where() {
+    let sql = "SELECT id, name FROM users WHERE id = 1";
+    let statements = parse(sql).unwrap();
+    let common_stmt = statements[0].to_common_ast().unwrap();
+
+    let config = EmitterConfig::default();
+    let mut emitter = MySqlEmitter::new(config);
+    let mysql_sql = emitter.emit(&common_stmt).unwrap();
+
+    assert!(mysql_sql.contains("SELECT"));
+    assert!(mysql_sql.contains("FROM"));
+    assert!(mysql_sql.contains("WHERE"));
+}
+
+/// UPDATE文の発行テスト
+#[test]
+fn test_emit_update() {
+    let sql = "UPDATE users SET name = 'Bob' WHERE id = 1";
+    let statements = parse(sql).unwrap();
+    let common_stmt = statements[0].to_common_ast().unwrap();
+
+    let config = EmitterConfig::default();
+    let mut emitter = MySqlEmitter::new(config);
+    let mysql_sql = emitter.emit(&common_stmt).unwrap();
+
+    assert!(mysql_sql.contains("UPDATE"));
+    assert!(mysql_sql.contains("SET"));
+    assert!(mysql_sql.contains("WHERE"));
+}
+
+/// emit_batch で複数ステートメントを発行
+#[test]
+fn test_emit_batch() {
+    let sql = "SELECT * FROM t1\nSELECT * FROM t2";
+    let statements = parse(sql).unwrap();
+    let common_stmts: Vec<_> = statements
+        .iter()
+        .filter_map(|s| s.to_common_ast())
+        .collect();
+
+    assert!(
+        common_stmts.len() >= 2,
+        "Should parse at least 2 statements"
+    );
+
+    let config = EmitterConfig::default();
+    let mut emitter = MySqlEmitter::new(config);
+    let mysql_sql = emitter.emit_batch(&common_stmts).unwrap();
+
+    assert!(
+        mysql_sql.contains(";\n"),
+        "Batch should be semicolon-separated"
+    );
+}
+
+/// ORDER BY付きSELECTの発行テスト
+#[test]
+fn test_emit_select_order_by() {
+    let sql = "SELECT * FROM users ORDER BY name ASC";
+    let statements = parse(sql).unwrap();
+    let common_stmt = statements[0].to_common_ast().unwrap();
+
+    let config = EmitterConfig::default();
+    let mut emitter = MySqlEmitter::new(config);
+    let mysql_sql = emitter.emit(&common_stmt).unwrap();
+
+    assert!(mysql_sql.contains("ORDER BY"));
+    assert!(mysql_sql.contains("ASC"));
+}
+
+/// SELECT DISTINCTの発行テスト
+#[test]
+fn test_emit_select_distinct() {
+    let sql = "SELECT DISTINCT id FROM users";
+    let statements = parse(sql).unwrap();
+    let common_stmt = statements[0].to_common_ast().unwrap();
+
+    let config = EmitterConfig::default();
+    let mut emitter = MySqlEmitter::new(config);
+    let mysql_sql = emitter.emit(&common_stmt).unwrap();
+
+    assert!(mysql_sql.contains("DISTINCT"));
+}

--- a/crates/postgresql-emitter/src/mappers/datatype.rs
+++ b/crates/postgresql-emitter/src/mappers/datatype.rs
@@ -43,7 +43,7 @@ impl DataTypeMapper {
             CommonDataType::DoublePrecision => "DOUBLE PRECISION".to_string(),
             CommonDataType::Float { precision } => {
                 if let Some(p) = precision {
-                    format!("FLOAT({})", p)
+                    format!("FLOAT({p})")
                 } else {
                     "FLOAT".to_string()
                 }
@@ -77,8 +77,8 @@ impl DataTypeMapper {
     /// DECIMAL/NUMERIC 型をフォーマット
     fn format_decimal(precision: Option<u8>, scale: Option<u8>) -> String {
         match (precision, scale) {
-            (Some(p), Some(s)) => format!("NUMERIC({},{})", p, s),
-            (Some(p), None) => format!("NUMERIC({})", p),
+            (Some(p), Some(s)) => format!("NUMERIC({p},{s})"),
+            (Some(p), None) => format!("NUMERIC({p})"),
             (None, _) => "NUMERIC".to_string(),
         }
     }
@@ -86,7 +86,7 @@ impl DataTypeMapper {
     /// CHAR/NCHAR 型をフォーマット
     fn format_char(base: &str, length: Option<u64>) -> String {
         match length {
-            Some(n) => format!("{}({})", base, n),
+            Some(n) => format!("{base}({n})"),
             None => base.to_string(),
         }
     }
@@ -94,7 +94,7 @@ impl DataTypeMapper {
     /// VARCHAR 型をフォーマット
     fn format_varchar(length: Option<u64>) -> String {
         match length {
-            Some(n) => format!("VARCHAR({})", n),
+            Some(n) => format!("VARCHAR({n})"),
             None => "VARCHAR".to_string(),
         }
     }
@@ -102,7 +102,7 @@ impl DataTypeMapper {
     /// TIME/TIMESTAMP 型をフォーマット
     fn format_time(base: &str, precision: Option<u8>) -> String {
         match precision {
-            Some(p) => format!("{}({})", base, p),
+            Some(p) => format!("{base}({p})"),
             None => base.to_string(),
         }
     }
@@ -110,7 +110,7 @@ impl DataTypeMapper {
     /// BINARY 型をフォーマット
     fn format_binary(base: &str, length: Option<u64>) -> String {
         match length {
-            Some(n) => format!("{}({})", base, n),
+            Some(n) => format!("{base}({n})"),
             None => base.to_string(),
         }
     }
@@ -118,7 +118,7 @@ impl DataTypeMapper {
     /// VARBINARY 型をフォーマット
     fn format_varbinary(length: Option<u64>) -> String {
         match length {
-            Some(n) => format!("BYTEA({})", n),
+            Some(n) => format!("BYTEA({n})"),
             None => "BYTEA".to_string(),
         }
     }

--- a/crates/postgresql-emitter/src/mappers/expression.rs
+++ b/crates/postgresql-emitter/src/mappers/expression.rs
@@ -155,7 +155,7 @@ impl ExpressionEmitter {
         // * はワイルドカードとして特別扱い
         if col.column == "*" {
             return match &col.table {
-                Some(table) => format!("{}.*", table),
+                Some(table) => format!("{table}.*"),
                 None => "*".to_string(),
             };
         }

--- a/crates/postgresql-emitter/src/mappers/function.rs
+++ b/crates/postgresql-emitter/src/mappers/function.rs
@@ -170,7 +170,7 @@ impl FunctionMapper {
             _ => part,
         };
 
-        Ok(format!("{} + INTERVAL '{} {}'", date, n, postgres_part))
+        Ok(format!("{date} + INTERVAL '{n} {postgres_part}'"))
     }
 
     /// DATEDIFF を変換
@@ -204,10 +204,7 @@ impl FunctionMapper {
             _ => part,
         };
 
-        Ok(format!(
-            "DATE_PART('{}', {} - {})",
-            postgres_part, end, start
-        ))
+        Ok(format!("DATE_PART('{postgres_part}', {end} - {start})"))
     }
 }
 

--- a/crates/postgresql-emitter/src/mappers/identifier.rs
+++ b/crates/postgresql-emitter/src/mappers/identifier.rs
@@ -460,7 +460,7 @@ impl IdentifierQuoter {
         if Self::needs_quoting(identifier) {
             // ダブルクォートを二重にエスケープ
             let escaped = identifier.replace('"', "\"\"");
-            format!("\"{}\"", escaped)
+            format!("\"{escaped}\"")
         } else {
             // クォート不要（PostgreSQL は自動的に小文字に変換）
             identifier.to_string()

--- a/crates/postgresql-emitter/src/mappers/select_statement.rs
+++ b/crates/postgresql-emitter/src/mappers/select_statement.rs
@@ -116,7 +116,7 @@ impl SelectStatementRenderer {
                         IdentifierQuoter::quote(alias_name)
                     )
                 } else {
-                    format!("({})", subquery_str)
+                    format!("({subquery_str})")
                 }
             }
         }
@@ -126,9 +126,9 @@ impl SelectStatementRenderer {
     fn emit_order_by_item(item: &CommonOrderByItem) -> String {
         let expr_str = ExpressionEmitter::emit(&item.expr);
         if item.asc {
-            format!("{} ASC", expr_str)
+            format!("{expr_str} ASC")
         } else {
-            format!("{} DESC", expr_str)
+            format!("{expr_str} DESC")
         }
     }
 
@@ -137,9 +137,9 @@ impl SelectStatementRenderer {
         let limit_str = ExpressionEmitter::emit(&limit.limit);
         if let Some(offset) = &limit.offset {
             let offset_str = ExpressionEmitter::emit(offset);
-            format!("LIMIT {} OFFSET {}", limit_str, offset_str)
+            format!("LIMIT {limit_str} OFFSET {offset_str}")
         } else {
-            format!("LIMIT {}", limit_str)
+            format!("LIMIT {limit_str}")
         }
     }
 }

--- a/crates/sqlite-emitter/src/lib.rs
+++ b/crates/sqlite-emitter/src/lib.rs
@@ -668,9 +668,9 @@ impl SqliteEmitter {
 
         // SQLiteの修飾子を生成
         let modifier = if adjusted_number >= 0 {
-            format!("+{} {}", adjusted_number, modifier_unit)
+            format!("+{adjusted_number} {modifier_unit}")
         } else {
-            format!("{} {}", adjusted_number, modifier_unit)
+            format!("{adjusted_number} {modifier_unit}")
         };
 
         // 第3引数: date (式)
@@ -685,14 +685,14 @@ impl SqliteEmitter {
         if is_getdate {
             // GETDATE/GETUTCDATE: datetime('now', modifier) または date('now', modifier)
             if use_datetime {
-                self.write(&format!("datetime('now', '{}')", modifier));
+                self.write(&format!("datetime('now', '{modifier}')"));
             } else {
-                self.write(&format!("date('now', '{}')", modifier));
+                self.write(&format!("date('now', '{modifier}')"));
             }
         } else {
             // その他の式: date(base_expr, modifier) または datetime(base_expr, modifier)
             let base_expr = match &func.args[2] {
-                CommonExpression::Literal(CommonLiteral::String(s)) => format!("'{}'", s),
+                CommonExpression::Literal(CommonLiteral::String(s)) => format!("'{s}'"),
                 CommonExpression::Literal(CommonLiteral::Integer(n)) => n.to_string(),
                 CommonExpression::Identifier(ident) => ident.name.clone(),
                 CommonExpression::ColumnReference(col) => {
@@ -714,9 +714,9 @@ impl SqliteEmitter {
 
             // SQLite形式の式を生成
             if use_datetime {
-                self.write(&format!("datetime({}, '{}')", base_expr, modifier));
+                self.write(&format!("datetime({base_expr}, '{modifier}')"));
             } else {
-                self.write(&format!("date({}, '{}')", base_expr, modifier));
+                self.write(&format!("date({base_expr}, '{modifier}')"));
             }
         }
 
@@ -763,8 +763,7 @@ impl SqliteEmitter {
 
         // SQLite形式の式を生成
         self.write(&format!(
-            "(julianday({}) - julianday({}))",
-            end_date, start_date
+            "(julianday({end_date}) - julianday({start_date}))"
         ));
 
         Ok(())
@@ -775,7 +774,7 @@ impl SqliteEmitter {
         use tsql_parser::common::{CommonExpression, CommonLiteral};
 
         match expr {
-            CommonExpression::Literal(CommonLiteral::String(s)) => Ok(format!("'{}'", s)),
+            CommonExpression::Literal(CommonLiteral::String(s)) => Ok(format!("'{s}'")),
             CommonExpression::Literal(CommonLiteral::Integer(n)) => Ok(n.to_string()),
             CommonExpression::Identifier(ident) => Ok(ident.name.clone()),
             CommonExpression::ColumnReference(col) => {
@@ -887,7 +886,7 @@ impl SqliteEmitter {
         // ESCAPE句を出力
         if let Some(esc) = escape {
             let escape_str = self.visit_expression(esc)?;
-            self.write(&format!(" ESCAPE {}", escape_str));
+            self.write(&format!(" ESCAPE {escape_str}"));
         }
 
         Ok(())

--- a/crates/sqlite-emitter/tests/emit_test.rs
+++ b/crates/sqlite-emitter/tests/emit_test.rs
@@ -1,0 +1,111 @@
+//! SQLite Emitter integration tests
+//!
+//! Common SQL AST → SQLite SQL 変換のテスト。
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+#![allow(clippy::expect_used)]
+
+use sqlite_emitter::{EmitterConfig, SqliteEmitter};
+use tsql_parser::{parse, ToCommonAst};
+
+/// SELECT * FROM の基本的な発行テスト
+#[test]
+fn test_emit_select_star() {
+    let sql = "SELECT * FROM users";
+    let statements = parse(sql).unwrap();
+    let common_stmt = statements[0].to_common_ast().unwrap();
+
+    let config = EmitterConfig::default();
+    let mut emitter = SqliteEmitter::new(config);
+    let sqlite_sql = emitter.emit(&common_stmt).unwrap();
+
+    assert!(sqlite_sql.contains("SELECT *"));
+    assert!(sqlite_sql.contains("users"));
+}
+
+/// WHERE句付きSELECTの発行テスト
+#[test]
+fn test_emit_select_with_where() {
+    let sql = "SELECT id, name FROM users WHERE id = 1";
+    let statements = parse(sql).unwrap();
+    let common_stmt = statements[0].to_common_ast().unwrap();
+
+    let config = EmitterConfig::default();
+    let mut emitter = SqliteEmitter::new(config);
+    let sqlite_sql = emitter.emit(&common_stmt).unwrap();
+
+    assert!(sqlite_sql.contains("SELECT"));
+    assert!(sqlite_sql.contains("FROM"));
+    assert!(sqlite_sql.contains("WHERE"));
+}
+
+/// UPDATE文の発行テスト
+#[test]
+fn test_emit_update() {
+    let sql = "UPDATE users SET name = 'Bob' WHERE id = 1";
+    let statements = parse(sql).unwrap();
+    let common_stmt = statements[0].to_common_ast().unwrap();
+
+    let config = EmitterConfig::default();
+    let mut emitter = SqliteEmitter::new(config);
+    let sqlite_sql = emitter.emit(&common_stmt).unwrap();
+
+    assert!(sqlite_sql.contains("UPDATE"));
+    assert!(sqlite_sql.contains("SET"));
+    assert!(sqlite_sql.contains("WHERE"));
+}
+
+/// emit_batch で複数ステートメントを発行
+#[test]
+fn test_emit_batch() {
+    let sql = "SELECT * FROM t1\nSELECT * FROM t2";
+    let statements = parse(sql).unwrap();
+    let common_stmts: Vec<_> = statements
+        .iter()
+        .filter_map(|s| s.to_common_ast())
+        .collect();
+
+    assert!(
+        common_stmts.len() >= 2,
+        "Should parse at least 2 statements"
+    );
+
+    let config = EmitterConfig::default();
+    let mut emitter = SqliteEmitter::new(config);
+    let sqlite_sql = emitter.emit_batch(&common_stmts).unwrap();
+
+    assert!(
+        sqlite_sql.contains(";\n"),
+        "Batch should be semicolon-separated"
+    );
+}
+
+/// ORDER BY付きSELECTの発行テスト
+#[test]
+fn test_emit_select_order_by() {
+    let sql = "SELECT * FROM users ORDER BY name ASC";
+    let statements = parse(sql).unwrap();
+    let common_stmt = statements[0].to_common_ast().unwrap();
+
+    let config = EmitterConfig::default();
+    let mut emitter = SqliteEmitter::new(config);
+    let sqlite_sql = emitter.emit(&common_stmt).unwrap();
+
+    assert!(sqlite_sql.contains("ORDER BY"));
+    assert!(sqlite_sql.contains("ASC"));
+}
+
+/// SELECT DISTINCTの発行テスト
+#[test]
+fn test_emit_select_distinct() {
+    let sql = "SELECT DISTINCT id FROM users";
+    let statements = parse(sql).unwrap();
+    let common_stmt = statements[0].to_common_ast().unwrap();
+
+    let config = EmitterConfig::default();
+    let mut emitter = SqliteEmitter::new(config);
+    let sqlite_sql = emitter.emit(&common_stmt).unwrap();
+
+    assert!(sqlite_sql.contains("DISTINCT"));
+}

--- a/crates/tsql-lexer/src/cursor.rs
+++ b/crates/tsql-lexer/src/cursor.rs
@@ -99,7 +99,7 @@ impl<'src> Cursor<'src> {
 
     /// EOF かどうかを判定する
     #[must_use]
-    pub fn is_eof(&self) -> bool {
+    pub const fn is_eof(&self) -> bool {
         self.current.is_none()
     }
 
@@ -117,7 +117,7 @@ impl<'src> Cursor<'src> {
     /// # Arguments
     ///
     /// * `width` - タブ幅（デフォルトは8）
-    pub fn set_tab_width(&mut self, width: u32) {
+    pub const fn set_tab_width(&mut self, width: u32) {
         self.tab_width = width;
     }
 }

--- a/crates/tsql-lexer/src/error.rs
+++ b/crates/tsql-lexer/src/error.rs
@@ -114,7 +114,7 @@ impl LexError {
 
     /// エラー位置を取得する
     #[must_use]
-    pub fn position(&self) -> Position {
+    pub const fn position(&self) -> Position {
         match self {
             Self::UnterminatedString { start, .. } => *start,
             Self::UnterminatedBlockComment { start, .. } => *start,

--- a/crates/tsql-lexer/src/error.rs
+++ b/crates/tsql-lexer/src/error.rs
@@ -106,7 +106,7 @@ impl LexError {
             Self::UnterminatedBlockComment { .. } => "Unterminated block comment".to_string(),
             Self::UnterminatedIdentifier { .. } => "Unterminated quoted identifier".to_string(),
             Self::InvalidCharacter { ch, .. } => {
-                format!("Invalid character in SQL: '{}'", ch)
+                format!("Invalid character in SQL: '{ch}'")
             }
             Self::UnexpectedEof { .. } => "Unexpected end of file".to_string(),
         }
@@ -160,7 +160,7 @@ impl LexError {
             self.position().column
         );
         if let Some(excerpt) = self.source_excerpt() {
-            msg.push_str(&format!("\n  | {}", excerpt));
+            msg.push_str(&format!("\n  | {excerpt}"));
         }
         msg
     }

--- a/crates/tsql-lexer/src/lexer.rs
+++ b/crates/tsql-lexer/src/lexer.rs
@@ -103,7 +103,7 @@ impl<'src> Lexer<'src> {
     /// # Arguments
     ///
     /// * `preserve` - true の場合、コメントトークンを保持する
-    pub fn with_comments(mut self, preserve: bool) -> Self {
+    pub const fn with_comments(mut self, preserve: bool) -> Self {
         self.preserve_comments = preserve;
         self
     }
@@ -786,7 +786,7 @@ impl<'src> Lexer<'src> {
     ///
     /// エラーが1つ以上記録されている場合は `true`
     #[must_use]
-    pub fn has_errors(&self) -> bool {
+    pub const fn has_errors(&self) -> bool {
         !self.errors.is_empty()
     }
 

--- a/crates/tsql-parser/src/ast/expression.rs
+++ b/crates/tsql-parser/src/ast/expression.rs
@@ -133,7 +133,7 @@ pub enum Literal {
 
 impl Literal {
     /// リテラルのspanを返す
-    pub fn span(&self) -> Span {
+    pub const fn span(&self) -> Span {
         match self {
             Literal::String(_, s) => *s,
             Literal::Number(_, s) => *s,

--- a/crates/tsql-parser/src/ast/to_common.rs
+++ b/crates/tsql-parser/src/ast/to_common.rs
@@ -27,27 +27,27 @@ impl ToCommonAst for Statement {
             | Statement::Transaction(_)
             | Statement::Throw(_)
             | Statement::Raiserror(_) => Some(CommonStatement::DialectSpecific {
-                description: format!("{:?}", self),
+                description: format!("{self:?}"),
                 span: self.span(),
             }),
             // CREATE文も方言固有として扱う（DDLは実装で差が大きいため）
             Statement::Create(_) => Some(CommonStatement::DialectSpecific {
-                description: format!("CREATE statement: {:?}", self),
+                description: format!("CREATE statement: {self:?}"),
                 span: self.span(),
             }),
             // ALTER TABLE文も方言固有
             Statement::AlterTable(_) => Some(CommonStatement::DialectSpecific {
-                description: format!("ALTER TABLE statement: {:?}", self),
+                description: format!("ALTER TABLE statement: {self:?}"),
                 span: self.span(),
             }),
             // EXEC/EXECUTE文も方言固有
             Statement::Exec(_) => Some(CommonStatement::DialectSpecific {
-                description: format!("EXEC statement: {:?}", self),
+                description: format!("EXEC statement: {self:?}"),
                 span: self.span(),
             }),
             // 変数代入文も方言固有
             Statement::VariableAssignment(_) => Some(CommonStatement::DialectSpecific {
-                description: format!("Variable assignment: {:?}", self),
+                description: format!("Variable assignment: {self:?}"),
                 span: self.span(),
             }),
             // バッチ区切りはCommon ASTには含めない

--- a/crates/tsql-parser/src/buffer.rs
+++ b/crates/tsql-parser/src/buffer.rs
@@ -213,7 +213,7 @@ impl<'src> TokenBuffer<'src> {
 /// 注意: TokenBufferはEOF時の正確な位置情報を追跡していないため、
 /// デフォルト位置（1行目、1列目、オフセット0）を返す。
 /// 改善にはLexerの最終位置を追跡する必要がある。
-fn position_at_eof() -> tsql_token::Position {
+const fn position_at_eof() -> tsql_token::Position {
     tsql_token::Position {
         line: 1,
         column: 1,

--- a/crates/tsql-parser/src/error.rs
+++ b/crates/tsql-parser/src/error.rs
@@ -131,9 +131,9 @@ impl fmt::Display for ParseError {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{:?}", kind)?;
+                    write!(f, "{kind:?}")?;
                 }
-                write!(f, ", found {:?}", found)
+                write!(f, ", found {found:?}")
             }
             Self::UnexpectedEof { expected, position } => write!(
                 f,
@@ -155,7 +155,7 @@ impl fmt::Display for ParseError {
             Self::BatchError {
                 batch_number,
                 error,
-            } => write!(f, "error in batch {}: {}", batch_number, error),
+            } => write!(f, "error in batch {batch_number}: {error}"),
         }
     }
 }

--- a/crates/tsql-parser/src/error.rs
+++ b/crates/tsql-parser/src/error.rs
@@ -56,7 +56,7 @@ pub enum ParseError {
 impl ParseError {
     /// 予期しないトークンエラーを作成
     #[must_use]
-    pub fn unexpected_token(
+    pub const fn unexpected_token(
         expected: Vec<TokenKind>,
         found: TokenKind,
         position: Position,
@@ -70,19 +70,19 @@ impl ParseError {
 
     /// 予期しないEOFエラーを作成
     #[must_use]
-    pub fn unexpected_eof(expected: String, position: Position) -> Self {
+    pub const fn unexpected_eof(expected: String, position: Position) -> Self {
         Self::UnexpectedEof { expected, position }
     }
 
     /// 無効な構文エラーを作成
     #[must_use]
-    pub fn invalid_syntax(message: String, position: Position) -> Self {
+    pub const fn invalid_syntax(message: String, position: Position) -> Self {
         Self::InvalidSyntax { message, position }
     }
 
     /// 再帰制限超過エラーを作成
     #[must_use]
-    pub fn recursion_limit(limit: usize, position: Position) -> Self {
+    pub const fn recursion_limit(limit: usize, position: Position) -> Self {
         Self::RecursionLimitExceeded { limit, position }
     }
 
@@ -177,19 +177,19 @@ pub struct ParseErrors {
 impl ParseErrors {
     /// 新しいParseErrorsを作成
     #[must_use]
-    pub fn new(errors: Vec<ParseError>) -> Self {
+    pub const fn new(errors: Vec<ParseError>) -> Self {
         Self { errors }
     }
 
     /// エラーが空かどうかを確認
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.errors.is_empty()
     }
 
     /// エラーの数を返す
     #[must_use]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.errors.len()
     }
 

--- a/crates/tsql-parser/src/expression/binary.rs
+++ b/crates/tsql-parser/src/expression/binary.rs
@@ -28,7 +28,7 @@ pub enum BindingPower {
 
 impl super::ExpressionParser<'_, '_> {
     /// 中置演算子の結合力を取得
-    pub(super) fn get_infix_binding_power(
+    pub(super) const fn get_infix_binding_power(
         kind: TokenKind,
     ) -> Option<(BindingPower, BinaryOperator)> {
         Some(match kind {
@@ -63,7 +63,7 @@ impl super::ExpressionParser<'_, '_> {
     }
 
     /// 二項演算子のspanを作成
-    pub(super) fn span_for_binary(&self, left: Span, right: Span) -> Span {
+    pub(super) const fn span_for_binary(&self, left: Span, right: Span) -> Span {
         Span {
             start: left.start,
             end: right.end,

--- a/crates/tsql-parser/src/expression/mod.rs
+++ b/crates/tsql-parser/src/expression/mod.rs
@@ -39,7 +39,7 @@ impl<'a, 'src> ExpressionParser<'a, 'src> {
     }
 
     /// 最大再帰深度を設定
-    pub fn with_max_depth(mut self, max: usize) -> Self {
+    pub const fn with_max_depth(mut self, max: usize) -> Self {
         self.max_depth = max;
         self
     }

--- a/crates/tsql-parser/src/expression/prefix.rs
+++ b/crates/tsql-parser/src/expression/prefix.rs
@@ -187,7 +187,7 @@ impl super::ExpressionParser<'_, '_> {
     }
 
     /// キーワードを識別子として解析可能かチェック
-    fn can_keyword_be_identifier(kind: TokenKind) -> bool {
+    const fn can_keyword_be_identifier(kind: TokenKind) -> bool {
         matches!(
             kind,
             // 型名

--- a/crates/tsql-parser/src/expression/special.rs
+++ b/crates/tsql-parser/src/expression/special.rs
@@ -117,10 +117,7 @@ impl super::ExpressionParser<'_, '_> {
                 "UNKNOWN" => IsValue::Unknown,
                 _ => {
                     return Err(ParseError::invalid_syntax(
-                        format!(
-                            "Expected NULL, TRUE, FALSE, or UNKNOWN after IS, found '{}'",
-                            text
-                        ),
+                        format!("Expected NULL, TRUE, FALSE, or UNKNOWN after IS, found '{text}'"),
                         position,
                     ))
                 }

--- a/crates/tsql-parser/src/lib.rs
+++ b/crates/tsql-parser/src/lib.rs
@@ -81,6 +81,7 @@ pub use tsql_lexer::Token;
 /// let statements = parse(sql).unwrap();
 /// assert_eq!(statements.len(), 1);
 /// ```
+#[must_use = "parsing result should be used"]
 pub fn parse(input: &str) -> ParseResult<Vec<Statement>> {
     let mut parser = Parser::new(input);
     parser.parse()
@@ -104,6 +105,7 @@ pub fn parse(input: &str) -> ParseResult<Vec<Statement>> {
 /// let sql = "SELECT * FROM users";
 /// let stmt = parse_one(sql).unwrap();
 /// ```
+#[must_use = "parsing result should be used"]
 pub fn parse_one(input: &str) -> ParseResult<Statement> {
     let mut parser = Parser::new(input).with_mode(ParserMode::SingleStatement);
     parser.parse_statement()
@@ -140,6 +142,7 @@ pub fn parse_one(input: &str) -> ParseResult<Statement> {
 /// let result = parse_with_errors(sql);
 /// assert!(result.is_err());
 /// ```
+#[must_use = "parsing result should be used"]
 pub fn parse_with_errors(input: &str) -> Result<(Vec<Statement>, Vec<ParseError>), ParseErrors> {
     let mut parser = Parser::new(input);
     parser.parse_with_errors()

--- a/crates/tsql-parser/src/parser.rs
+++ b/crates/tsql-parser/src/parser.rs
@@ -1569,7 +1569,14 @@ impl<'src> Parser<'src> {
                 let len = if self.buffer.check(TokenKind::LParen) {
                     self.buffer.consume()?;
                     let n = if self.buffer.check(TokenKind::Number) {
-                        let n = self.buffer.current()?.text.parse().unwrap_or(1);
+                        let token = self.buffer.current()?;
+                        let num_str = token.text;
+                        let n = num_str.parse::<u32>().map_err(|_| {
+                            ParseError::invalid_syntax(
+                                format!("Invalid number for BINARY length: {num_str}"),
+                                token.position,
+                            )
+                        })?;
                         self.buffer.consume()?;
                         n
                     } else {

--- a/crates/tsql-parser/src/parser.rs
+++ b/crates/tsql-parser/src/parser.rs
@@ -60,7 +60,7 @@ impl<'src> Parser<'src> {
     /// # Arguments
     ///
     /// * `mode` - パーサーモード
-    pub fn with_mode(mut self, mode: ParserMode) -> Self {
+    pub const fn with_mode(mut self, mode: ParserMode) -> Self {
         self.mode = mode;
         self
     }
@@ -153,7 +153,7 @@ impl<'src> Parser<'src> {
     ///
     /// エラーがある場合はtrue
     #[must_use]
-    pub fn has_errors(&self) -> bool {
+    pub const fn has_errors(&self) -> bool {
         !self.errors.is_empty()
     }
 

--- a/crates/tsql-parser/src/parser.rs
+++ b/crates/tsql-parser/src/parser.rs
@@ -60,6 +60,7 @@ impl<'src> Parser<'src> {
     /// # Arguments
     ///
     /// * `mode` - パーサーモード
+    #[must_use]
     pub const fn with_mode(mut self, mode: ParserMode) -> Self {
         self.mode = mode;
         self

--- a/crates/tsql-parser/src/parser.rs
+++ b/crates/tsql-parser/src/parser.rs
@@ -1448,7 +1448,7 @@ impl<'src> Parser<'src> {
                         let num_str = token.text;
                         let n = num_str.parse::<u32>().map_err(|_| {
                             ParseError::invalid_syntax(
-                                format!("Invalid number for VARCHAR length: {}", num_str),
+                                format!("Invalid number for VARCHAR length: {num_str}"),
                                 token.position,
                             )
                         })?;
@@ -1480,7 +1480,7 @@ impl<'src> Parser<'src> {
                         let num_str = token.text;
                         let parsed = num_str.parse::<u32>().map_err(|_| {
                             ParseError::invalid_syntax(
-                                format!("Invalid number for CHAR length: {}", num_str),
+                                format!("Invalid number for CHAR length: {num_str}"),
                                 token.position,
                             )
                         })?;
@@ -1511,7 +1511,7 @@ impl<'src> Parser<'src> {
                         let num_str = token.text;
                         let parsed = num_str.parse::<u8>().map_err(|_| {
                             ParseError::invalid_syntax(
-                                format!("Invalid number for DECIMAL precision: {}", num_str),
+                                format!("Invalid number for DECIMAL precision: {num_str}"),
                                 token.position,
                             )
                         })?;
@@ -1527,7 +1527,7 @@ impl<'src> Parser<'src> {
                             let num_str = token.text;
                             let parsed = num_str.parse::<u8>().map_err(|_| {
                                 ParseError::invalid_syntax(
-                                    format!("Invalid number for DECIMAL scale: {}", num_str),
+                                    format!("Invalid number for DECIMAL scale: {num_str}"),
                                     token.position,
                                 )
                             })?;


### PR DESCRIPTION
## Summary

Session 21 code quality improvements across `ase-ls-core`.

### Changes

**String literal deduplication:**
- Extract `TRY_CATCH_LABEL` const in `code_actions.rs`
- Extract `KEYWORD_DETAIL` const in `completion.rs`

**Zero-allocation case-insensitive search:**
- `find_ignore_ascii_case()` / `contains_ignore_ascii_case()` in `code_actions.rs` — replaces `line_text.to_uppercase()` allocation
- `ends_with_ignore_ascii_case()` in `references.rs` — replaces `trimmed.to_uppercase()` allocation
- `CaseInsensitiveKey.as_str()` in `workspace_symbols.rs` — uses pre-normalized key instead of per-symbol `.to_uppercase()`
- Remove unnecessary `to_uppercase()` in `hover.rs` `build_column_hover` (downstream already uses `eq_ignore_ascii_case`)

**Removed unnecessary allocations:**
- 2x `get_line().to_string()` → `&str` in `code_actions.rs`

**`#[must_use]` annotations (12 functions):**
- `line_index.rs`: `offset_to_position`, `position_to_offset`, `line_count`, `line_offset`, `offset_to_range`
- `diagnostics.rs`: `diagnose`
- `formatting.rs`: `format`
- `semantic_tokens.rs`: `semantic_tokens_full_with_analysis`, `semantic_tokens_range_with_analysis`

**Doc comments:** `add_fold_if_multiline`, `resolve_column_in_statement`

**Tests (+11):**
- `definition`: INDEX, variable in WHILE
- `rename`: case-insensitive table, multi-reference variable
- `signature_help`: CONVERT, GETDATE, SUBSTRING active_parameter
- `code_actions`: `find_ignore_ascii_case` (3 tests), `contains_ignore_ascii_case` (1 test)
- `references`: `ends_with_ignore_ascii_case` (1 test)

### Test plan
- [x] `cargo nextest run --workspace` — 1054 passed, 2 skipped
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: glm 4.7 <noreply@zhipuai.cn>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced allocations and faster hot-path lookups for snappier editor responses; semantic token encoding optimized to avoid duplicate work.

* **Code Quality**
  * More lintable APIs (ignored-return warnings) and wider compile-time evaluations for stability; several internal helpers improved for efficiency and correctness.

* **Documentation**
  * Project status updated to Session 24 with refreshed metrics and a consolidated change summary.

* **Tests**
  * Expanded unit and integration coverage, including semantic token scenarios and MySQL/SQLite emitter tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->