### PR TITLE
feat(common-sql): tsql-parser → common-sql 変換ブリッジ完了（#148）

### DIFF
--- a/.kiro/specs/common-sql-ast/design.md
+++ b/.kiro/specs/common-sql-ast/design.md
@@ -51,20 +51,30 @@ common-sql/
 
 ### Span（位置情報）
 
+> **CTO Review 修正**: `tsql_token::Span { start: u32, end: u32 }` と同じバイトオフセット形式を採用。
+> ゼロ依存原則を維持しつつ、`From<tsql_token::Span>` による変換を容易にする。
+
 ```rust
-/// ソースコード内の位置情報
+/// ソースコード内の位置情報（バイトオフセット）
+/// tsql_token::Span と同一レイアウト — 変換時の LineIndex 不要
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Span {
-    pub start: Position,
-    pub end: Position,
+    pub start: u32,
+    pub end: u32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Position {
-    pub line: usize,
-    pub column: usize,
-    pub offset: usize,
+impl Span {
+    pub fn new(start: u32, end: u32) -> Self {
+        Self { start, end }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
 }
+
+// tsql-token からの変換は conversion layer (tsql-parser) で実装:
+// impl From<tsql_token::Span> for Span { ... }
 ```
 
 ### Statement ノード
@@ -519,15 +529,22 @@ pub struct TableOptions {
 
 ## Visitor パターン設計
 
+> **CTO Review 修正**: 全 visit メソッドに default implementation を提供。
+> 新しい AST バリアント追加時に全 Visitor 実装の更新が不要になる（Open-Closed 原則）。
+
 ### Visitor Trait
 
 ```rust
 /// Visitor trait - SQL 生成用
+/// 全メソッドに default implementation あり — 必要なものだけオーバーライド可能
 pub trait Visitor: Sized {
     /// 訪問の結果型
     type Output;
 
-    /// Statement を訪問
+    /// デフォルトの出力（オーバーライド可能）
+    fn default_output(&self) -> Self::Output;
+
+    /// Statement を訪問（default impl）
     fn visit_statement(&mut self, stmt: &Statement) -> Self::Output {
         match stmt {
             Statement::Select(s) => self.visit_select_statement(s),
@@ -542,18 +559,18 @@ pub trait Visitor: Sized {
         }
     }
 
-    /// 各 Statement タイプの訪問メソッド
-    fn visit_select_statement(&mut self, stmt: &SelectStatement) -> Self::Output;
-    fn visit_insert_statement(&mut self, stmt: &InsertStatement) -> Self::Output;
-    fn visit_update_statement(&mut self, stmt: &UpdateStatement) -> Self::Output;
-    fn visit_delete_statement(&mut self, stmt: &DeleteStatement) -> Self::Output;
-    fn visit_create_table_statement(&mut self, stmt: &CreateTableStatement) -> Self::Output;
-    fn visit_alter_table_statement(&mut self, stmt: &AlterTableStatement) -> Self::Output;
-    fn visit_drop_table_statement(&mut self, stmt: &DropTableStatement) -> Self::Output;
-    fn visit_create_index_statement(&mut self, stmt: &CreateIndexStatement) -> Self::Output;
-    fn visit_drop_index_statement(&mut self, stmt: &DropIndexStatement) -> Self::Output;
+    /// 各 Statement タイプの訪問メソッド（default: default_output を返す）
+    fn visit_select_statement(&mut self, _stmt: &SelectStatement) -> Self::Output { self.default_output() }
+    fn visit_insert_statement(&mut self, _stmt: &InsertStatement) -> Self::Output { self.default_output() }
+    fn visit_update_statement(&mut self, _stmt: &UpdateStatement) -> Self::Output { self.default_output() }
+    fn visit_delete_statement(&mut self, _stmt: &DeleteStatement) -> Self::Output { self.default_output() }
+    fn visit_create_table_statement(&mut self, _stmt: &CreateTableStatement) -> Self::Output { self.default_output() }
+    fn visit_alter_table_statement(&mut self, _stmt: &AlterTableStatement) -> Self::Output { self.default_output() }
+    fn visit_drop_table_statement(&mut self, _stmt: &DropTableStatement) -> Self::Output { self.default_output() }
+    fn visit_create_index_statement(&mut self, _stmt: &CreateIndexStatement) -> Self::Output { self.default_output() }
+    fn visit_drop_index_statement(&mut self, _stmt: &DropIndexStatement) -> Self::Output { self.default_output() }
 
-    /// Expression を訪問
+    /// Expression を訪問（default impl）
     fn visit_expression(&mut self, expr: &Expression) -> Self::Output {
         match expr {
             Expression::Literal(l) => self.visit_literal(l),
@@ -592,25 +609,25 @@ pub trait Visitor: Sized {
         }
     }
 
-    /// 各 Expression タイプの訪問メソッド
-    fn visit_literal(&mut self, literal: &Literal) -> Self::Output;
-    fn visit_identifier(&mut self, ident: &Identifier) -> Self::Output;
-    fn visit_qualified_identifier(&mut self, table: &Identifier, column: &Identifier) -> Self::Output;
-    fn visit_binary_op(&mut self, left: &Expression, op: BinaryOperator, right: &Expression) -> Self::Output;
-    fn visit_unary_op(&mut self, op: UnaryOperator, expr: &Expression) -> Self::Output;
-    fn visit_logical_op(&mut self, left: &Expression, op: LogicalOperator, right: &Expression) -> Self::Output;
-    fn visit_comparison(&mut self, left: &Expression, op: ComparisonOperator, right: &Expression) -> Self::Output;
-    fn visit_function(&mut self, name: &Identifier, args: &[Expression], distinct: bool) -> Self::Output;
-    fn visit_case(&mut self, operand: &Option<Box<Expression>>, conditions: &[(Expression, Expression)], else_result: &Option<Box<Expression>>) -> Self::Output;
-    fn visit_subquery(&mut self, subquery: &SelectStatement) -> Self::Output;
-    fn visit_exists(&mut self, subquery: &SelectStatement, negated: bool) -> Self::Output;
-    fn visit_in(&mut self, expr: &Expression, list: &InList, negated: bool) -> Self::Output;
-    fn visit_between(&mut self, expr: &Expression, low: &Expression, high: &Expression, negated: bool) -> Self::Output;
-    fn visit_cast(&mut self, expr: &Expression, data_type: &DataType) -> Self::Output;
-    fn visit_is_null(&mut self, expr: &Expression, negated: bool) -> Self::Output;
+    /// 各 Expression タイプの訪問メソッド（default: default_output を返す）
+    fn visit_literal(&mut self, _literal: &Literal) -> Self::Output { self.default_output() }
+    fn visit_identifier(&mut self, _ident: &Identifier) -> Self::Output { self.default_output() }
+    fn visit_qualified_identifier(&mut self, _table: &Identifier, _column: &Identifier) -> Self::Output { self.default_output() }
+    fn visit_binary_op(&mut self, _left: &Expression, _op: BinaryOperator, _right: &Expression) -> Self::Output { self.default_output() }
+    fn visit_unary_op(&mut self, _op: UnaryOperator, _expr: &Expression) -> Self::Output { self.default_output() }
+    fn visit_logical_op(&mut self, _left: &Expression, _op: LogicalOperator, _right: &Expression) -> Self::Output { self.default_output() }
+    fn visit_comparison(&mut self, _left: &Expression, _op: ComparisonOperator, _right: &Expression) -> Self::Output { self.default_output() }
+    fn visit_function(&mut self, _name: &Identifier, _args: &[Expression], _distinct: bool) -> Self::Output { self.default_output() }
+    fn visit_case(&mut self, _operand: &Option<Box<Expression>>, _conditions: &[(Expression, Expression)], _else_result: &Option<Box<Expression>>) -> Self::Output { self.default_output() }
+    fn visit_subquery(&mut self, _subquery: &SelectStatement) -> Self::Output { self.default_output() }
+    fn visit_exists(&mut self, _subquery: &SelectStatement, _negated: bool) -> Self::Output { self.default_output() }
+    fn visit_in(&mut self, _expr: &Expression, _list: &InList, _negated: bool) -> Self::Output { self.default_output() }
+    fn visit_between(&mut self, _expr: &Expression, _low: &Expression, _high: &Expression, _negated: bool) -> Self::Output { self.default_output() }
+    fn visit_cast(&mut self, _expr: &Expression, _data_type: &DataType) -> Self::Output { self.default_output() }
+    fn visit_is_null(&mut self, _expr: &Expression, _negated: bool) -> Self::Output { self.default_output() }
 
-    /// DataType を訪問
-    fn visit_data_type(&mut self, data_type: &DataType) -> Self::Output;
+    /// DataType を訪問（default: default_output を返す）
+    fn visit_data_type(&mut self, _data_type: &DataType) -> Self::Output { self.default_output() }
 }
 ```
 
@@ -692,26 +709,26 @@ impl Visitable for DataType {
 
 ### 方言固有機能の扱い
 
+> **CTO Review 修正**: 下位クレートが上位の型に依存する `DialectOptions { mysql, postgres, tsql }` は
+> アーキテクチャ原則違反（`architecture-coupling-balance.md` セクション7）。
+> 代わりに `DialectHint` による汎用メタデータアプローチを採用。
+
 ```rust
-// 方言固有のオプションを表現するパターン
+/// 方言固有のメタデータ（汎用キー・バリュー形式）
+/// 下位クレート (common-sql) は上位クレートの型に依存しない
 #[derive(Debug, Clone, PartialEq)]
-pub struct DialectOptions {
-    pub mysql: Option<MySqlOptions>,
-    pub postgres: Option<PostgresOptions>,
-    pub tsql: Option<TSqlOptions>,
+pub struct DialectHint {
+    pub key: String,
+    pub value: String,
 }
 
-// 各方言が特別な機能を持つ場合
-#[derive(Debug, Clone, PartialEq)]
-pub struct CreateTableStatement {
-    pub span: Span,
-    pub if_not_exists: bool,
-    pub name: QualifiedName,
-    pub columns: Vec<ColumnDef>,
-    pub constraints: Vec<TableConstraint>,
-    pub options: TableOptions,
-    pub dialect_options: DialectOptions,  // 拡張ポイント
-}
+// 使用例:
+// MySQL: DialectHint { key: "engine", value: "InnoDB" }
+// ASE:   DialectHint { key: "lock_scheme", value: "allpages" }
+// PostgreSQL: DialectHint { key: "tablespace", value: "pg_default" }
+//
+// 各エミッタが独自にキーを定義し、変換層が生成する。
+// common-sql 自体はキーの意味を解釈しない。
 ```
 
 ## 実装時の注意事項

--- a/.kiro/specs/common-sql-ast/design.md
+++ b/.kiro/specs/common-sql-ast/design.md
@@ -32,20 +32,31 @@
 common-sql/
 ├── Cargo.toml
 ├── src/
-│   ├── lib.rs              # 公開APIの再エクスポート
-│   ├── mod.rs              # モジュール宣言
+│   ├── lib.rs              # 公開APIの再エクスポート（Visitor/Visitable 含む）
 │   ├── ast/
-│   │   ├── mod.rs          # AST モジュール
-│   │   ├── statement.rs    # Statement ノード
+│   │   ├── mod.rs          # AST モジュール（公開型の再エクスポート）
+│   │   ├── statement.rs    # Statement enum + DML（Select/Insert/Update/Delete）
+│   │   ├── ddl.rs          # DDL ノード（Create/Alter/Drop Table, Create/Drop Index）
 │   │   ├── expression.rs   # Expression ノード
 │   │   ├── datatype.rs     # DataType ノード
-│   │   ├── clause.rs       # クエリ句（FROM, WHERE 等）
+│   │   ├── clause.rs       # クエリ句（FROM, WHERE, ORDER BY, LIMIT 等）
+│   │   ├── join.rs         # JOIN / TableFactor 表現
+│   │   ├── identifier.rs   # Identifier / QualifiedName / TableAlias
+│   │   ├── literal.rs      # Literal
 │   │   └── span.rs         # 位置情報
-│   └── visitor.rs          # Visitor trait
+│   └── visitor.rs          # Visitor / Visitable trait
 └── tests/
-    ├── ast_tests.rs        # AST 単体テスト
-    └── visitor_tests.rs    # Visitor テスト
+    ├── scaffold_tests.rs   # AST 構築スキャフォールド
+    ├── reexport_dml.rs     # DML 公開面の到達性テスト
+    ├── reexport_ddl.rs     # DDL 公開面の到達性テスト
+    └── visitor_tests.rs    # Visitor 統合テスト
 ```
+
+> **Task 5.1 実装逸脱（記録）**: tasks.md Task 5.1 は DDL 型を `statement.rs` へ追記する計画だったが、
+> 凝集性のため DDL 型は独立した `ast/ddl.rs` モジュールに抽出した（`clause.rs` / `join.rs` 等の
+> カテゴリ別分割と一致）。`statement.rs` は `Statement` enum の DDL バリアントのみ保持する。
+> また enum サイズ不変量のため全バリアントを `Box<T>` で包む（`clippy::large_enum_variant` 回避；
+> 詳細は下記 `Statement` ノードの定義参照）。
 
 ## データ構造設計
 
@@ -83,15 +94,15 @@ impl Span {
 /// SQL 文の種類
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
-    Select(SelectStatement),
-    Insert(InsertStatement),
-    Update(UpdateStatement),
-    Delete(DeleteStatement),
-    CreateTable(CreateTableStatement),
-    AlterTable(AlterTableStatement),
-    DropTable(DropTableStatement),
-    CreateIndex(CreateIndexStatement),
-    DropIndex(DropIndexStatement),
+    Select(Box<SelectStatement>),
+    Insert(Box<InsertStatement>),
+    Update(Box<UpdateStatement>),
+    Delete(Box<DeleteStatement>),
+    CreateTable(Box<CreateTableStatement>),
+    AlterTable(Box<AlterTableStatement>),
+    DropTable(Box<DropTableStatement>),
+    CreateIndex(Box<CreateIndexStatement>),
+    DropIndex(Box<DropIndexStatement>),
 }
 
 /// SELECT 文

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "common-sql"
+version = "0.1.0"
+dependencies = [
+ "rstest",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,6 +1730,7 @@ dependencies = [
 name = "tsql-parser"
 version = "0.1.0"
 dependencies = [
+ "common-sql",
  "criterion",
  "rstest",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/tsql-token",
     "crates/tsql-lexer",
     "crates/tsql-parser",
+    "crates/common-sql",
     "crates/mysql-emitter",
     "crates/postgresql-emitter",
     "crates/sqlite-emitter",

--- a/crates/common-sql/Cargo.toml
+++ b/crates/common-sql/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "common-sql"
+version = "0.1.0"
+edition = "2021"
+description = "Dialect-independent common SQL AST"
+
+[dependencies]
+
+[dev-dependencies]
+rstest = { workspace = true }
+
+[lints]
+# workspace.lintsを継承
+workspace = true

--- a/crates/common-sql/src/ast/clause.rs
+++ b/crates/common-sql/src/ast/clause.rs
@@ -1,0 +1,507 @@
+//! SQL query clause nodes: GROUP BY, ORDER BY, LIMIT, WITH (CTE).
+
+use crate::ast::span::Span;
+use crate::ast::statement::SelectStatement;
+use crate::ast::Expression;
+
+// ---------------------------------------------------------------------------
+// GROUP BY
+// ---------------------------------------------------------------------------
+
+/// An item in a `GROUP BY` clause.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GroupByItem {
+    /// A plain expression: `GROUP BY col`.
+    Expression(Expression),
+    /// `ROLLUP(expr, ...)`.
+    Rollup(Vec<Expression>),
+    /// `CUBE(expr, ...)`.
+    Cube(Vec<Expression>),
+    /// `GROUPING SETS((expr, ...), ...)`.
+    GroupingSets(Vec<Vec<Expression>>),
+}
+
+/// `GROUP BY` clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroupByClause {
+    /// Source span.
+    pub span: Span,
+    /// Group-by items.
+    pub items: Vec<GroupByItem>,
+}
+
+// ---------------------------------------------------------------------------
+// ORDER BY
+// ---------------------------------------------------------------------------
+
+/// Sort direction for `ORDER BY`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SortDirection {
+    /// Ascending (`ASC`).
+    Asc,
+    /// Descending (`DESC`).
+    Desc,
+}
+
+/// Null ordering within a sort.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NullOrdering {
+    /// `NULLS FIRST`.
+    NullsFirst,
+    /// `NULLS LAST`.
+    NullsLast,
+}
+
+/// An item in an `ORDER BY` clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrderByItem {
+    /// The expression to sort by.
+    pub expr: Expression,
+    /// Sort direction — `None` means implicit `ASC`.
+    pub direction: Option<SortDirection>,
+    /// Null ordering — `None` means database default.
+    pub nulls: Option<NullOrdering>,
+}
+
+/// `ORDER BY` clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrderByClause {
+    /// Source span.
+    pub span: Span,
+    /// Sort items.
+    pub items: Vec<OrderByItem>,
+}
+
+// ---------------------------------------------------------------------------
+// LIMIT
+// ---------------------------------------------------------------------------
+
+/// `LIMIT` / `OFFSET` clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LimitClause {
+    /// Source span.
+    pub span: Span,
+    /// Maximum number of rows to return.
+    pub limit: Expression,
+    /// Number of rows to skip.
+    pub offset: Option<Expression>,
+}
+
+// ---------------------------------------------------------------------------
+// WITH (CTE)
+// ---------------------------------------------------------------------------
+
+/// A single Common Table Expression (`name AS (query)`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Cte {
+    /// CTE name.
+    pub name: String,
+    /// Optional column alias list: `name (col1, col2) AS (...)`.
+    pub columns: Vec<String>,
+    /// The subquery defining the CTE.
+    pub query: Box<SelectStatement>,
+    /// `MATERIALIZED` / `NOT MATERIALIZED` hint (`None` = unspecified).
+    pub materialized: Option<bool>,
+}
+
+/// `WITH` clause (one or more CTEs).
+#[derive(Debug, Clone, PartialEq)]
+pub struct WithClause {
+    /// `true` for `WITH RECURSIVE`.
+    pub recursive: bool,
+    /// CTE definitions.
+    pub ctes: Vec<Cte>,
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::ast::literal::Literal;
+    use crate::ast::SelectItem;
+
+    // Helper to build a trivial expression.
+    fn int_expr(n: i64) -> Expression {
+        Expression::Literal(Literal::Integer(n))
+    }
+
+    fn ident_expr(name: &str) -> Expression {
+        Expression::Identifier(crate::ast::Identifier::new(name.to_string()))
+    }
+
+    fn simple_select() -> SelectStatement {
+        SelectStatement::simple(vec![SelectItem::Wildcard])
+    }
+
+    // ===== GroupByItem =====
+
+    #[test]
+    fn group_by_item_expression() {
+        let item = GroupByItem::Expression(ident_expr("department"));
+        assert!(matches!(item, GroupByItem::Expression(_)));
+    }
+
+    #[test]
+    fn group_by_item_rollup() {
+        let item = GroupByItem::Rollup(vec![ident_expr("year"), ident_expr("month")]);
+        if let GroupByItem::Rollup(exprs) = &item {
+            assert_eq!(exprs.len(), 2);
+        } else {
+            panic!("expected Rollup");
+        }
+    }
+
+    #[test]
+    fn group_by_item_cube() {
+        let item = GroupByItem::Cube(vec![ident_expr("region"), ident_expr("product")]);
+        if let GroupByItem::Cube(exprs) = &item {
+            assert_eq!(exprs.len(), 2);
+        } else {
+            panic!("expected Cube");
+        }
+    }
+
+    #[test]
+    fn group_by_item_grouping_sets() {
+        let item = GroupByItem::GroupingSets(vec![
+            vec![ident_expr("a")],
+            vec![ident_expr("b"), ident_expr("c")],
+        ]);
+        if let GroupByItem::GroupingSets(sets) = &item {
+            assert_eq!(sets.len(), 2);
+            assert_eq!(sets[1].len(), 2);
+        } else {
+            panic!("expected GroupingSets");
+        }
+    }
+
+    // ===== GroupByClause =====
+
+    #[test]
+    fn group_by_clause_with_items() {
+        let clause = GroupByClause {
+            span: Span::new(10, 30),
+            items: vec![
+                GroupByItem::Expression(ident_expr("dept")),
+                GroupByItem::Expression(ident_expr("year")),
+            ],
+        };
+        assert_eq!(clause.items.len(), 2);
+        assert_eq!(clause.span.start, 10);
+    }
+
+    #[test]
+    fn group_by_clause_empty_items() {
+        let clause = GroupByClause {
+            span: Span::default(),
+            items: vec![],
+        };
+        assert!(clause.items.is_empty());
+    }
+
+    #[test]
+    fn group_by_clause_mixed_items() {
+        let clause = GroupByClause {
+            span: Span::new(0, 50),
+            items: vec![
+                GroupByItem::Expression(ident_expr("a")),
+                GroupByItem::Rollup(vec![ident_expr("b")]),
+                GroupByItem::Cube(vec![ident_expr("c")]),
+            ],
+        };
+        assert_eq!(clause.items.len(), 3);
+    }
+
+    // ===== SortDirection =====
+
+    #[test]
+    fn sort_direction_copy_and_equality() {
+        let asc = SortDirection::Asc;
+        let desc = SortDirection::Desc;
+        let asc_copy = asc; // Copy
+        assert_eq!(asc, asc_copy);
+        assert_ne!(asc, desc);
+    }
+
+    // ===== NullOrdering =====
+
+    #[test]
+    fn null_ordering_copy_and_equality() {
+        let first = NullOrdering::NullsFirst;
+        let last = NullOrdering::NullsLast;
+        let first_copy = first; // Copy
+        assert_eq!(first, first_copy);
+        assert_ne!(first, last);
+    }
+
+    // ===== OrderByItem =====
+
+    #[test]
+    fn order_by_item_with_direction() {
+        let item = OrderByItem {
+            expr: ident_expr("name"),
+            direction: Some(SortDirection::Asc),
+            nulls: None,
+        };
+        assert_eq!(item.direction, Some(SortDirection::Asc));
+        assert!(item.nulls.is_none());
+    }
+
+    #[test]
+    fn order_by_item_with_nulls_first() {
+        let item = OrderByItem {
+            expr: ident_expr("salary"),
+            direction: Some(SortDirection::Desc),
+            nulls: Some(NullOrdering::NullsFirst),
+        };
+        assert_eq!(item.direction, Some(SortDirection::Desc));
+        assert_eq!(item.nulls, Some(NullOrdering::NullsFirst));
+    }
+
+    #[test]
+    fn order_by_item_without_direction() {
+        // Implicit ASC — direction is None
+        let item = OrderByItem {
+            expr: int_expr(1),
+            direction: None,
+            nulls: None,
+        };
+        assert!(item.direction.is_none());
+    }
+
+    // ===== OrderByClause =====
+
+    #[test]
+    fn order_by_clause_multiple_items() {
+        let clause = OrderByClause {
+            span: Span::new(20, 60),
+            items: vec![
+                OrderByItem {
+                    expr: ident_expr("last_name"),
+                    direction: Some(SortDirection::Asc),
+                    nulls: None,
+                },
+                OrderByItem {
+                    expr: ident_expr("first_name"),
+                    direction: Some(SortDirection::Desc),
+                    nulls: Some(NullOrdering::NullsLast),
+                },
+            ],
+        };
+        assert_eq!(clause.items.len(), 2);
+    }
+
+    #[test]
+    fn order_by_clause_empty_items() {
+        let clause = OrderByClause {
+            span: Span::default(),
+            items: vec![],
+        };
+        assert!(clause.items.is_empty());
+    }
+
+    // ===== LimitClause =====
+
+    #[test]
+    fn limit_clause_without_offset() {
+        let clause = LimitClause {
+            span: Span::new(40, 50),
+            limit: int_expr(10),
+            offset: None,
+        };
+        assert_eq!(clause.span.start, 40);
+        assert!(clause.offset.is_none());
+    }
+
+    #[test]
+    fn limit_clause_with_offset() {
+        let clause = LimitClause {
+            span: Span::new(40, 60),
+            limit: int_expr(20),
+            offset: Some(int_expr(5)),
+        };
+        assert_eq!(clause.offset, Some(int_expr(5)));
+    }
+
+    // ===== Cte =====
+
+    #[test]
+    fn cte_basic() {
+        let cte = Cte {
+            name: "sq".to_string(),
+            columns: vec![],
+            query: Box::new(simple_select()),
+            materialized: None,
+        };
+        assert_eq!(cte.name, "sq");
+        assert!(cte.columns.is_empty());
+        assert!(cte.materialized.is_none());
+    }
+
+    #[test]
+    fn cte_with_column_list() {
+        let cte = Cte {
+            name: "src".to_string(),
+            columns: vec!["id".to_string(), "name".to_string()],
+            query: Box::new(simple_select()),
+            materialized: None,
+        };
+        assert_eq!(cte.columns.len(), 2);
+        assert_eq!(cte.columns[0], "id");
+    }
+
+    #[test]
+    fn cte_with_materialized() {
+        let cte = Cte {
+            name: "mat".to_string(),
+            columns: vec![],
+            query: Box::new(simple_select()),
+            materialized: Some(true),
+        };
+        assert_eq!(cte.materialized, Some(true));
+    }
+
+    #[test]
+    fn cte_not_materialized() {
+        let cte = Cte {
+            name: "nomat".to_string(),
+            columns: vec![],
+            query: Box::new(simple_select()),
+            materialized: Some(false),
+        };
+        assert_eq!(cte.materialized, Some(false));
+    }
+
+    // ===== WithClause =====
+
+    #[test]
+    fn with_clause_non_recursive() {
+        let wc = WithClause {
+            recursive: false,
+            ctes: vec![Cte {
+                name: "t".to_string(),
+                columns: vec![],
+                query: Box::new(simple_select()),
+                materialized: None,
+            }],
+        };
+        assert!(!wc.recursive);
+        assert_eq!(wc.ctes.len(), 1);
+    }
+
+    #[test]
+    fn with_clause_recursive() {
+        let wc = WithClause {
+            recursive: true,
+            ctes: vec![Cte {
+                name: "r".to_string(),
+                columns: vec!["n".to_string()],
+                query: Box::new(simple_select()),
+                materialized: None,
+            }],
+        };
+        assert!(wc.recursive);
+        assert_eq!(wc.ctes[0].columns.len(), 1);
+    }
+
+    #[test]
+    fn with_clause_multiple_ctes() {
+        let wc = WithClause {
+            recursive: false,
+            ctes: vec![
+                Cte {
+                    name: "a".to_string(),
+                    columns: vec![],
+                    query: Box::new(simple_select()),
+                    materialized: None,
+                },
+                Cte {
+                    name: "b".to_string(),
+                    columns: vec!["x".to_string()],
+                    query: Box::new(simple_select()),
+                    materialized: Some(true),
+                },
+            ],
+        };
+        assert_eq!(wc.ctes.len(), 2);
+    }
+
+    #[test]
+    fn with_clause_empty_ctes() {
+        let wc = WithClause {
+            recursive: false,
+            ctes: vec![],
+        };
+        assert!(wc.ctes.is_empty());
+    }
+
+    // ===== Clone / PartialEq =====
+
+    #[test]
+    fn group_by_clause_clone_equality() {
+        let clause = GroupByClause {
+            span: Span::new(0, 10),
+            items: vec![GroupByItem::Expression(ident_expr("x"))],
+        };
+        let cloned = clause.clone();
+        assert_eq!(clause, cloned);
+    }
+
+    #[test]
+    fn order_by_clause_clone_equality() {
+        let clause = OrderByClause {
+            span: Span::new(5, 15),
+            items: vec![OrderByItem {
+                expr: ident_expr("y"),
+                direction: Some(SortDirection::Desc),
+                nulls: Some(NullOrdering::NullsFirst),
+            }],
+        };
+        let cloned = clause.clone();
+        assert_eq!(clause, cloned);
+    }
+
+    #[test]
+    fn limit_clause_clone_equality() {
+        let clause = LimitClause {
+            span: Span::new(0, 5),
+            limit: int_expr(100),
+            offset: Some(int_expr(10)),
+        };
+        let cloned = clause.clone();
+        assert_eq!(clause, cloned);
+    }
+
+    #[test]
+    fn cte_clone_equality() {
+        let cte = Cte {
+            name: "cte1".to_string(),
+            columns: vec!["a".to_string()],
+            query: Box::new(simple_select()),
+            materialized: Some(false),
+        };
+        let cloned = cte.clone();
+        assert_eq!(cte, cloned);
+    }
+
+    #[test]
+    fn with_clause_clone_equality() {
+        let wc = WithClause {
+            recursive: true,
+            ctes: vec![Cte {
+                name: "src".to_string(),
+                columns: vec![],
+                query: Box::new(simple_select()),
+                materialized: None,
+            }],
+        };
+        let cloned = wc.clone();
+        assert_eq!(wc, cloned);
+    }
+}

--- a/crates/common-sql/src/ast/datatype.rs
+++ b/crates/common-sql/src/ast/datatype.rs
@@ -471,6 +471,108 @@ mod tests {
         );
     }
 
+    // ── Debug output: exhaustive per-category variant coverage ──────────
+    // Every DataType variant's Debug representation must contain its own
+    // variant name. This guards against accidental Debug renames and
+    // satisfies the all-variant exhaustiveness requirement.
+
+    #[test]
+    fn debug_output_all_integer_variants() {
+        for (name, dt) in [
+            ("TinyInt", DataType::TinyInt),
+            ("SmallInt", DataType::SmallInt),
+            ("Int", DataType::Int),
+            ("BigInt", DataType::BigInt),
+        ] {
+            let debug = format!("{dt:?}");
+            assert!(
+                debug.contains(name),
+                "Debug output should contain '{name}': {debug}"
+            );
+        }
+    }
+
+    #[test]
+    fn debug_output_all_decimal_float_variants() {
+        let numeric = format!(
+            "{:?}",
+            DataType::Numeric {
+                precision: Some(10),
+                scale: None,
+            }
+        );
+        assert!(numeric.contains("Numeric"), "missing Numeric: {numeric}");
+        let real = format!("{:?}", DataType::Real);
+        assert!(real.contains("Real"), "missing Real: {real}");
+        let double = format!("{:?}", DataType::DoublePrecision);
+        assert!(
+            double.contains("DoublePrecision"),
+            "missing DoublePrecision: {double}"
+        );
+    }
+
+    #[test]
+    fn debug_output_all_string_variants() {
+        for (name, dt) in [("Text", DataType::Text), ("NText", DataType::NText)] {
+            let debug = format!("{dt:?}");
+            assert!(debug.contains(name), "missing {name}: {debug}");
+        }
+        let nchar = format!("{:?}", DataType::NChar { length: Some(5) });
+        assert!(nchar.contains("NChar"), "missing NChar: {nchar}");
+        let nvarchar = format!("{:?}", DataType::NVarChar { length: Some(5) });
+        assert!(
+            nvarchar.contains("NVarChar"),
+            "missing NVarChar: {nvarchar}"
+        );
+    }
+
+    #[test]
+    fn debug_output_all_datetime_variants() {
+        assert!(format!("{:?}", DataType::Date).contains("Date"));
+        assert!(format!("{:?}", DataType::Time { precision: None }).contains("Time"));
+        assert!(format!("{:?}", DataType::DateTime { precision: None }).contains("DateTime"));
+        assert!(format!("{:?}", DataType::Timestamp { precision: Some(6) }).contains("Timestamp"));
+    }
+
+    #[test]
+    fn debug_output_all_binary_variants() {
+        assert!(format!("{:?}", DataType::Binary { length: None }).contains("Binary"));
+        assert!(format!("{:?}", DataType::VarBinary { length: None }).contains("VarBinary"));
+        assert!(format!("{:?}", DataType::Blob).contains("Blob"));
+    }
+
+    #[test]
+    fn debug_output_all_other_variants() {
+        assert!(format!("{:?}", DataType::Boolean).contains("Boolean"));
+        assert!(format!("{:?}", DataType::Uuid).contains("Uuid"));
+        assert!(format!("{:?}", DataType::Json).contains("Json"));
+    }
+
+    #[test]
+    fn debug_output_includes_field_names_for_struct_variants() {
+        // Struct-variant Debug output must surface the field names so that
+        // downstream emitters can pattern-match on the rendered form.
+        let debug = format!(
+            "{:?}",
+            DataType::Decimal {
+                precision: Some(18),
+                scale: Some(4),
+            }
+        );
+        assert!(
+            debug.contains("precision"),
+            "missing precision field: {debug}"
+        );
+        assert!(debug.contains("scale"), "missing scale field: {debug}");
+    }
+
+    #[test]
+    fn debug_output_includes_length_field() {
+        let debug = format!("{:?}", DataType::Char { length: Some(42) });
+        assert!(debug.contains("length"), "missing length field: {debug}");
+        assert!(debug.contains("42"), "missing length value: {debug}");
+    }
+
     // ── Hash / Eq (HashSet usage) ───────────────────────
 
     #[test]
@@ -585,5 +687,105 @@ mod tests {
     #[test]
     fn real_is_distinct_from_int() {
         assert_ne!(DataType::Real, DataType::Int);
+    }
+
+    // ── Exhaustiveness: every variant is constructible & distinct ────────
+    // Enumerates every DataType variant once. If a new variant is added
+    // without updating this list, the count assertion fails — surfacing the
+    // coverage gap rather than silently letting it regress.
+
+    #[test]
+    fn every_variant_constructible_and_clones_equal() {
+        let all = vec![
+            DataType::TinyInt,
+            DataType::SmallInt,
+            DataType::Int,
+            DataType::BigInt,
+            DataType::Decimal {
+                precision: None,
+                scale: None,
+            },
+            DataType::Numeric {
+                precision: None,
+                scale: None,
+            },
+            DataType::Real,
+            DataType::DoublePrecision,
+            DataType::Char { length: None },
+            DataType::VarChar { length: None },
+            DataType::Text,
+            DataType::NChar { length: None },
+            DataType::NVarChar { length: None },
+            DataType::NText,
+            DataType::Date,
+            DataType::Time { precision: None },
+            DataType::DateTime { precision: None },
+            DataType::Timestamp { precision: None },
+            DataType::Binary { length: None },
+            DataType::VarBinary { length: None },
+            DataType::Blob,
+            DataType::Boolean,
+            DataType::Uuid,
+            DataType::Json,
+        ];
+        // 24 variants currently defined. Bump this when adding a variant.
+        assert_eq!(all.len(), 24, "DataType variant count changed; update test");
+        for dt in &all {
+            assert_eq!(dt.clone(), *dt, "clone should equal original for {dt:?}");
+        }
+    }
+
+    // ── Edge cases: None optionals and minimal parametrized forms ───────
+
+    #[test]
+    fn numeric_with_no_params_distinct_from_decimal_no_params() {
+        assert_ne!(
+            DataType::Numeric {
+                precision: None,
+                scale: None,
+            },
+            DataType::Decimal {
+                precision: None,
+                scale: None,
+            }
+        );
+    }
+
+    #[test]
+    fn time_zero_precision_is_valid() {
+        let dt = DataType::Time { precision: Some(0) };
+        assert_eq!(dt, DataType::Time { precision: Some(0) });
+    }
+
+    #[test]
+    fn timestamp_none_vs_some_zero_differ() {
+        assert_ne!(
+            DataType::Timestamp { precision: None },
+            DataType::Timestamp { precision: Some(0) }
+        );
+    }
+
+    #[test]
+    fn binary_none_vs_some_zero_differ() {
+        assert_ne!(
+            DataType::Binary { length: None },
+            DataType::Binary { length: Some(0) }
+        );
+    }
+
+    #[test]
+    fn unit_variants_round_trip_through_eq() {
+        // The four zero-field unit variants must compare equal to themselves.
+        let pairs = [
+            (DataType::Text, DataType::Text),
+            (DataType::NText, DataType::NText),
+            (DataType::Blob, DataType::Blob),
+            (DataType::Boolean, DataType::Boolean),
+            (DataType::Uuid, DataType::Uuid),
+            (DataType::Json, DataType::Json),
+        ];
+        for (a, b) in pairs {
+            assert_eq!(a, b);
+        }
     }
 }

--- a/crates/common-sql/src/ast/datatype.rs
+++ b/crates/common-sql/src/ast/datatype.rs
@@ -1,0 +1,589 @@
+//! SQL data type definitions.
+
+/// SQL data type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DataType {
+    // Integer types
+    /// 1-byte integer (`TINYINT`).
+    TinyInt,
+    /// 2-byte integer (`SMALLINT`).
+    SmallInt,
+    /// 4-byte integer (`INT` / `INTEGER`).
+    Int,
+    /// 8-byte integer (`BIGINT`).
+    BigInt,
+
+    // Decimal types
+    /// Fixed-point decimal (`DECIMAL(p, s)`).
+    Decimal {
+        /// Total digit count.
+        precision: Option<u8>,
+        /// Digits after the decimal point.
+        scale: Option<u8>,
+    },
+    /// Fixed-point numeric (`NUMERIC(p, s)`).
+    Numeric {
+        /// Total digit count.
+        precision: Option<u8>,
+        /// Digits after the decimal point.
+        scale: Option<u8>,
+    },
+    /// Single-precision floating point (`REAL`).
+    Real,
+    /// Double-precision floating point (`DOUBLE PRECISION`).
+    DoublePrecision,
+
+    // String types
+    /// Fixed-length character string (`CHAR(n)`).
+    Char {
+        /// String length in characters.
+        length: Option<u64>,
+    },
+    /// Variable-length character string (`VARCHAR(n)`).
+    VarChar {
+        /// Maximum string length in characters.
+        length: Option<u64>,
+    },
+    /// Unlimited-length text (`TEXT`).
+    Text,
+    /// Fixed-length national character string (`NCHAR(n)`).
+    NChar {
+        /// String length in characters.
+        length: Option<u64>,
+    },
+    /// Variable-length national character string (`NVARCHAR(n)`).
+    NVarChar {
+        /// Maximum string length in characters.
+        length: Option<u64>,
+    },
+    /// Unlimited-length national text (`NTEXT`).
+    NText,
+
+    // Date/time types
+    /// Calendar date (`DATE`).
+    Date,
+    /// Time of day (`TIME(p)`).
+    Time {
+        /// Fractional seconds precision.
+        precision: Option<u8>,
+    },
+    /// Date and time (`DATETIME(p)`).
+    DateTime {
+        /// Fractional seconds precision.
+        precision: Option<u8>,
+    },
+    /// Date and time stamp (`TIMESTAMP(p)`).
+    Timestamp {
+        /// Fractional seconds precision.
+        precision: Option<u8>,
+    },
+
+    // Binary types
+    /// Fixed-length binary (`BINARY(n)`).
+    Binary {
+        /// Byte length.
+        length: Option<u64>,
+    },
+    /// Variable-length binary (`VARBINARY(n)`).
+    VarBinary {
+        /// Maximum byte length.
+        length: Option<u64>,
+    },
+    /// Binary large object (`BLOB`).
+    Blob,
+
+    // Other
+    /// Boolean (`BOOLEAN`).
+    Boolean,
+    /// Universally unique identifier (`UUID`).
+    Uuid,
+    /// JSON data (`JSON`).
+    Json,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    // ── Integer types: construction & equality ───────────
+
+    #[test]
+    fn tinyint_constructs_and_equals() {
+        let a = DataType::TinyInt;
+        let b = DataType::TinyInt;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn smallint_constructs_and_equals() {
+        assert_eq!(DataType::SmallInt, DataType::SmallInt);
+    }
+
+    #[test]
+    fn int_constructs_and_equals() {
+        assert_eq!(DataType::Int, DataType::Int);
+    }
+
+    #[test]
+    fn bigint_constructs_and_equals() {
+        assert_eq!(DataType::BigInt, DataType::BigInt);
+    }
+
+    #[test]
+    fn integer_types_are_distinct() {
+        let types = [
+            DataType::TinyInt,
+            DataType::SmallInt,
+            DataType::Int,
+            DataType::BigInt,
+        ];
+        for (i, a) in types.iter().enumerate() {
+            for (j, b) in types.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "{:?} should differ from {:?}", a, b);
+                }
+            }
+        }
+    }
+
+    // ── Decimal types: precision & scale ─────────────────
+
+    #[test]
+    fn decimal_with_both_precision_and_scale() {
+        let dt = DataType::Decimal {
+            precision: Some(18),
+            scale: Some(4),
+        };
+        assert_eq!(
+            dt,
+            DataType::Decimal {
+                precision: Some(18),
+                scale: Some(4),
+            }
+        );
+    }
+
+    #[test]
+    fn decimal_with_precision_only() {
+        let dt = DataType::Decimal {
+            precision: Some(10),
+            scale: None,
+        };
+        assert_eq!(
+            dt,
+            DataType::Decimal {
+                precision: Some(10),
+                scale: None,
+            }
+        );
+        assert_ne!(
+            dt,
+            DataType::Decimal {
+                precision: Some(10),
+                scale: Some(0),
+            }
+        );
+    }
+
+    #[test]
+    fn decimal_with_no_params() {
+        let dt = DataType::Decimal {
+            precision: None,
+            scale: None,
+        };
+        assert_eq!(
+            dt,
+            DataType::Decimal {
+                precision: None,
+                scale: None,
+            }
+        );
+    }
+
+    #[test]
+    fn numeric_with_precision_and_scale() {
+        let dt = DataType::Numeric {
+            precision: Some(38),
+            scale: Some(10),
+        };
+        assert_eq!(
+            dt,
+            DataType::Numeric {
+                precision: Some(38),
+                scale: Some(10),
+            }
+        );
+    }
+
+    #[test]
+    fn decimal_and_numeric_are_distinct() {
+        assert_ne!(
+            DataType::Decimal {
+                precision: Some(10),
+                scale: Some(2),
+            },
+            DataType::Numeric {
+                precision: Some(10),
+                scale: Some(2),
+            }
+        );
+    }
+
+    #[test]
+    fn real_constructs_and_equals() {
+        assert_eq!(DataType::Real, DataType::Real);
+    }
+
+    #[test]
+    fn double_precision_constructs_and_equals() {
+        assert_eq!(DataType::DoublePrecision, DataType::DoublePrecision);
+    }
+
+    #[test]
+    fn real_and_double_precision_are_distinct() {
+        assert_ne!(DataType::Real, DataType::DoublePrecision);
+    }
+
+    // ── String types: length parameter ───────────────────
+
+    #[test]
+    fn char_with_length() {
+        let dt = DataType::Char { length: Some(10) };
+        assert_eq!(dt, DataType::Char { length: Some(10) });
+    }
+
+    #[test]
+    fn char_without_length() {
+        let dt = DataType::Char { length: None };
+        assert_eq!(dt, DataType::Char { length: None });
+    }
+
+    #[test]
+    fn varchar_with_length() {
+        let dt = DataType::VarChar { length: Some(255) };
+        assert_eq!(dt, DataType::VarChar { length: Some(255) });
+    }
+
+    #[test]
+    fn varchar_without_length() {
+        let dt = DataType::VarChar { length: None };
+        assert_eq!(dt, DataType::VarChar { length: None });
+    }
+
+    #[test]
+    fn text_constructs_and_equals() {
+        assert_eq!(DataType::Text, DataType::Text);
+    }
+
+    #[test]
+    fn nchar_with_length() {
+        let dt = DataType::NChar { length: Some(50) };
+        assert_eq!(dt, DataType::NChar { length: Some(50) });
+    }
+
+    #[test]
+    fn nvarchar_with_length() {
+        let dt = DataType::NVarChar { length: Some(100) };
+        assert_eq!(dt, DataType::NVarChar { length: Some(100) });
+    }
+
+    #[test]
+    fn ntext_constructs_and_equals() {
+        assert_eq!(DataType::NText, DataType::NText);
+    }
+
+    #[test]
+    fn char_and_varchar_are_distinct_even_with_same_length() {
+        assert_ne!(
+            DataType::Char { length: Some(10) },
+            DataType::VarChar { length: Some(10) }
+        );
+    }
+
+    #[test]
+    fn char_and_nchar_are_distinct_even_with_same_length() {
+        assert_ne!(
+            DataType::Char { length: Some(10) },
+            DataType::NChar { length: Some(10) }
+        );
+    }
+
+    // ── Date/time types ──────────────────────────────────
+
+    #[test]
+    fn date_constructs_and_equals() {
+        assert_eq!(DataType::Date, DataType::Date);
+    }
+
+    #[test]
+    fn time_with_precision() {
+        let dt = DataType::Time { precision: Some(6) };
+        assert_eq!(dt, DataType::Time { precision: Some(6) });
+    }
+
+    #[test]
+    fn time_without_precision() {
+        let dt = DataType::Time { precision: None };
+        assert_eq!(dt, DataType::Time { precision: None });
+    }
+
+    #[test]
+    fn datetime_with_precision() {
+        let dt = DataType::DateTime { precision: Some(3) };
+        assert_eq!(dt, DataType::DateTime { precision: Some(3) });
+    }
+
+    #[test]
+    fn timestamp_with_precision() {
+        let dt = DataType::Timestamp { precision: Some(6) };
+        assert_eq!(dt, DataType::Timestamp { precision: Some(6) });
+    }
+
+    #[test]
+    fn date_and_datetime_are_distinct() {
+        assert_ne!(DataType::Date, DataType::DateTime { precision: None });
+    }
+
+    // ── Binary types: length parameter ──────────────────
+
+    #[test]
+    fn binary_with_length() {
+        let dt = DataType::Binary { length: Some(16) };
+        assert_eq!(dt, DataType::Binary { length: Some(16) });
+    }
+
+    #[test]
+    fn binary_without_length() {
+        let dt = DataType::Binary { length: None };
+        assert_eq!(dt, DataType::Binary { length: None });
+    }
+
+    #[test]
+    fn varbinary_with_length() {
+        let dt = DataType::VarBinary { length: Some(1024) };
+        assert_eq!(dt, DataType::VarBinary { length: Some(1024) });
+    }
+
+    #[test]
+    fn blob_constructs_and_equals() {
+        assert_eq!(DataType::Blob, DataType::Blob);
+    }
+
+    #[test]
+    fn binary_and_varbinary_are_distinct() {
+        assert_ne!(
+            DataType::Binary { length: Some(16) },
+            DataType::VarBinary { length: Some(16) }
+        );
+    }
+
+    // ── Other types ──────────────────────────────────────
+
+    #[test]
+    fn boolean_constructs_and_equals() {
+        assert_eq!(DataType::Boolean, DataType::Boolean);
+    }
+
+    #[test]
+    fn uuid_constructs_and_equals() {
+        assert_eq!(DataType::Uuid, DataType::Uuid);
+    }
+
+    #[test]
+    fn json_constructs_and_equals() {
+        assert_eq!(DataType::Json, DataType::Json);
+    }
+
+    #[test]
+    fn other_types_are_mutually_distinct() {
+        let types = [DataType::Boolean, DataType::Uuid, DataType::Json];
+        for (i, a) in types.iter().enumerate() {
+            for (j, b) in types.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "{:?} should differ from {:?}", a, b);
+                }
+            }
+        }
+    }
+
+    // ── Clone ────────────────────────────────────────────
+
+    #[test]
+    fn clone_simple_type() {
+        let dt = DataType::Int;
+        let cloned = dt.clone();
+        assert_eq!(dt, cloned);
+    }
+
+    #[test]
+    fn clone_parametrized_type() {
+        let dt = DataType::Decimal {
+            precision: Some(18),
+            scale: Some(4),
+        };
+        let cloned = dt.clone();
+        assert_eq!(dt, cloned);
+    }
+
+    #[test]
+    fn clone_varchar_with_length() {
+        let dt = DataType::VarChar { length: Some(100) };
+        let cloned = dt.clone();
+        assert_eq!(dt, cloned);
+    }
+
+    // ── Debug output ─────────────────────────────────────
+
+    #[test]
+    fn debug_output_simple_type() {
+        let debug = format!("{:?}", DataType::Int);
+        assert!(
+            debug.contains("Int"),
+            "Debug output should contain 'Int': {debug}"
+        );
+    }
+
+    #[test]
+    fn debug_output_decimal() {
+        let debug = format!(
+            "{:?}",
+            DataType::Decimal {
+                precision: Some(18),
+                scale: Some(4),
+            }
+        );
+        assert!(
+            debug.contains("Decimal"),
+            "Debug output should contain 'Decimal': {debug}"
+        );
+    }
+
+    #[test]
+    fn debug_output_varchar() {
+        let debug = format!("{:?}", DataType::VarChar { length: Some(255) });
+        assert!(
+            debug.contains("VarChar"),
+            "Debug output should contain 'VarChar': {debug}"
+        );
+    }
+
+    // ── Hash / Eq (HashSet usage) ───────────────────────
+
+    #[test]
+    fn eq_allows_hashset_dedup() {
+        let mut set = HashSet::new();
+        set.insert(DataType::Int);
+        set.insert(DataType::Int);
+        set.insert(DataType::BigInt);
+        assert_eq!(set.len(), 2, "HashSet should deduplicate equal types");
+    }
+
+    #[test]
+    fn eq_parametrized_types_with_same_params_are_equal() {
+        assert_eq!(
+            DataType::Decimal {
+                precision: Some(10),
+                scale: Some(2),
+            },
+            DataType::Decimal {
+                precision: Some(10),
+                scale: Some(2),
+            }
+        );
+    }
+
+    #[test]
+    fn eq_parametrized_types_with_different_params_are_not_equal() {
+        assert_ne!(
+            DataType::Decimal {
+                precision: Some(10),
+                scale: Some(2),
+            },
+            DataType::Decimal {
+                precision: Some(18),
+                scale: Some(2),
+            }
+        );
+        assert_ne!(
+            DataType::VarChar { length: Some(50) },
+            DataType::VarChar { length: Some(100) }
+        );
+    }
+
+    // ── Edge cases ───────────────────────────────────────
+
+    #[test]
+    fn precision_at_maximum_u8() {
+        let dt = DataType::Decimal {
+            precision: Some(u8::MAX),
+            scale: Some(u8::MAX),
+        };
+        assert_eq!(
+            dt,
+            DataType::Decimal {
+                precision: Some(255),
+                scale: Some(255),
+            }
+        );
+    }
+
+    #[test]
+    fn length_at_large_u64_value() {
+        let dt = DataType::VarChar {
+            length: Some(u64::MAX),
+        };
+        assert_eq!(
+            dt,
+            DataType::VarChar {
+                length: Some(u64::MAX),
+            }
+        );
+    }
+
+    #[test]
+    fn zero_length_is_valid() {
+        let dt = DataType::Char { length: Some(0) };
+        assert_eq!(dt, DataType::Char { length: Some(0) });
+    }
+
+    #[test]
+    fn zero_precision_and_scale_is_valid() {
+        let dt = DataType::Decimal {
+            precision: Some(0),
+            scale: Some(0),
+        };
+        assert_eq!(
+            dt,
+            DataType::Decimal {
+                precision: Some(0),
+                scale: Some(0),
+            }
+        );
+    }
+
+    // ── Cross-category distinctness ─────────────────────
+
+    #[test]
+    fn int_is_distinct_from_boolean() {
+        assert_ne!(DataType::Int, DataType::Boolean);
+    }
+
+    #[test]
+    fn date_is_distinct_from_timestamp() {
+        assert_ne!(DataType::Date, DataType::Timestamp { precision: None });
+    }
+
+    #[test]
+    fn text_is_distinct_from_blob() {
+        assert_ne!(DataType::Text, DataType::Blob);
+    }
+
+    #[test]
+    fn real_is_distinct_from_int() {
+        assert_ne!(DataType::Real, DataType::Int);
+    }
+}

--- a/crates/common-sql/src/ast/ddl.rs
+++ b/crates/common-sql/src/ast/ddl.rs
@@ -1,0 +1,802 @@
+//! DDL (Data Definition Language) statement nodes.
+//!
+//! Covers `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, `CREATE INDEX`, and
+//! `DROP INDEX`. These nodes form the dialect-independent representation that
+//! every SQL emitter consumes. Field shapes mirror `tsql-parser`'s
+//! `TableDefinition` / `IndexDefinition` so the future conversion layer is a
+//! near 1:1 mapping, and they carry the extra metadata the MySQL / PostgreSQL
+//! emitters need (engine, charset, `IF NOT EXISTS`, etc.).
+
+use crate::ast::clause::SortDirection;
+use crate::ast::datatype::DataType;
+use crate::ast::expression::Expression;
+use crate::ast::identifier::{Identifier, QualifiedName};
+use crate::ast::span::Span;
+
+// ---------------------------------------------------------------------------
+// Column / constraint primitives (shared by CREATE TABLE and ALTER TABLE)
+// ---------------------------------------------------------------------------
+
+/// A column definition inside a `CREATE TABLE` or `ALTER TABLE ... ADD`.
+///
+/// Represents `name data_type [NOT NULL] [DEFAULT expr] [constraints...]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnDef {
+    /// Source span of the column definition.
+    pub span: Span,
+    /// Column name.
+    pub name: Identifier,
+    /// Column data type.
+    pub data_type: DataType,
+    /// Whether the column allows NULL (`false` = `NOT NULL`).
+    ///
+    /// Defaults to `true` to match SQL's nullability default (columns are
+    /// nullable unless `NOT NULL` is specified).
+    pub nullable: bool,
+    /// Optional `DEFAULT` expression.
+    pub default: Option<Expression>,
+    /// Column-level constraints.
+    pub constraints: Vec<ColumnConstraint>,
+}
+
+/// A constraint attached to a single column.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ColumnConstraint {
+    /// `PRIMARY KEY` (column-level).
+    PrimaryKey,
+    /// `UNIQUE` (column-level).
+    Unique,
+    /// `CHECK (expr)` (column-level).
+    Check(Expression),
+    /// `REFERENCES table (columns...)` — a foreign key reference.
+    References {
+        /// Referenced table name.
+        table: QualifiedName,
+        /// Referenced column names.
+        columns: Vec<String>,
+    },
+    /// `AUTO_INCREMENT` / `IDENTITY`.
+    AutoIncrement,
+}
+
+/// A table-level constraint (named, multi-column).
+#[derive(Debug, Clone, PartialEq)]
+pub enum TableConstraint {
+    /// `PRIMARY KEY (cols...)`.
+    PrimaryKey {
+        /// Optional constraint name.
+        name: Option<String>,
+        /// Column list.
+        columns: Vec<Identifier>,
+    },
+    /// `UNIQUE (cols...)`.
+    Unique {
+        /// Optional constraint name.
+        name: Option<String>,
+        /// Column list.
+        columns: Vec<Identifier>,
+    },
+    /// `FOREIGN KEY (cols...) REFERENCES ref_table (ref_cols...)`.
+    ForeignKey {
+        /// Optional constraint name.
+        name: Option<String>,
+        /// Local column list.
+        columns: Vec<Identifier>,
+        /// Referenced table name.
+        ref_table: QualifiedName,
+        /// Referenced column list.
+        ref_columns: Vec<Identifier>,
+    },
+    /// `CHECK (expr)`.
+    Check {
+        /// Optional constraint name.
+        name: Option<String>,
+        /// Check predicate.
+        expr: Expression,
+    },
+}
+
+/// Storage / table-level options emitted after the column list.
+///
+/// These are mostly MySQL-specific (`ENGINE`, `CHARSET`, `COLLATE`,
+/// `COMMENT`) but harmless to other dialects, which ignore them.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct TableOptions {
+    /// Storage engine (e.g. `InnoDB`).
+    pub engine: Option<String>,
+    /// Character set (e.g. `utf8mb4`).
+    pub charset: Option<String>,
+    /// Collation (e.g. `utf8mb4_unicode_ci`).
+    pub collation: Option<String>,
+    /// Table comment.
+    pub comment: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// CREATE TABLE
+// ---------------------------------------------------------------------------
+
+/// `CREATE TABLE` statement.
+///
+/// Represents `CREATE [TEMPORARY] TABLE [IF NOT EXISTS] name (columns,
+/// constraints) options`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateTableStatement {
+    /// Source span of the entire statement.
+    pub span: Span,
+    /// `IF NOT EXISTS` guard.
+    pub if_not_exists: bool,
+    /// `TEMPORARY` flag.
+    pub temporary: bool,
+    /// Target table name (`schema.table` or just `table`).
+    pub name: QualifiedName,
+    /// Column definitions.
+    pub columns: Vec<ColumnDef>,
+    /// Table-level constraints.
+    pub constraints: Vec<TableConstraint>,
+    /// Table-level options (`ENGINE`, `CHARSET`, ...).
+    pub options: TableOptions,
+}
+
+// ---------------------------------------------------------------------------
+// ALTER TABLE
+// ---------------------------------------------------------------------------
+
+/// A single `ALTER TABLE` action.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AlterTableAction {
+    /// `ADD COLUMN col def` (the `COLUMN` keyword is optional in most dialects).
+    AddColumn(ColumnDef),
+    /// `DROP COLUMN col`.
+    DropColumn(Identifier),
+    /// `ALTER COLUMN col ...` (type / default changes).
+    AlterColumn {
+        /// Target column name.
+        column: Identifier,
+        /// New data type, if changed.
+        data_type: Option<DataType>,
+        /// New default expression, if changed (`Some(None)` drops the default).
+        default: Option<Option<Expression>>,
+        /// New nullability, if changed.
+        nullable: Option<bool>,
+    },
+    /// `ADD table-constraint`.
+    AddConstraint(TableConstraint),
+    /// `DROP CONSTRAINT name`.
+    DropConstraint(String),
+    /// `RENAME TO new_name`.
+    RenameTo(QualifiedName),
+}
+
+/// `ALTER TABLE` statement.
+///
+/// Carries the target table and an ordered list of [`AlterTableAction`]s.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlterTableStatement {
+    /// Source span of the entire statement.
+    pub span: Span,
+    /// Target table name.
+    pub name: QualifiedName,
+    /// Actions to apply, in source order.
+    pub actions: Vec<AlterTableAction>,
+}
+
+// ---------------------------------------------------------------------------
+// DROP TABLE
+// ---------------------------------------------------------------------------
+
+/// `DROP TABLE` statement.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DropTableStatement {
+    /// Source span of the entire statement.
+    pub span: Span,
+    /// `IF EXISTS` guard.
+    pub if_exists: bool,
+    /// Tables to drop.
+    pub names: Vec<QualifiedName>,
+}
+
+// ---------------------------------------------------------------------------
+// CREATE INDEX
+// ---------------------------------------------------------------------------
+
+/// An ordered column inside a `CREATE INDEX`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IndexColumn {
+    /// The indexed column (or expression identifier).
+    pub name: Identifier,
+    /// Sort direction (`ASC` / `DESC`); `None` means default.
+    ///
+    /// Reuses [`SortDirection`](crate::ast::clause::SortDirection) so that
+    /// index columns and `ORDER BY` items share one canonical type.
+    pub direction: Option<SortDirection>,
+}
+
+/// `CREATE [UNIQUE] INDEX name ON table (cols...)`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateIndexStatement {
+    /// Source span of the entire statement.
+    pub span: Span,
+    /// `UNIQUE` flag.
+    pub unique: bool,
+    /// `IF NOT EXISTS` guard.
+    pub if_not_exists: bool,
+    /// Index name.
+    pub name: Identifier,
+    /// Target table name.
+    pub table: QualifiedName,
+    /// Indexed columns (ordered).
+    pub columns: Vec<IndexColumn>,
+}
+
+// ---------------------------------------------------------------------------
+// DROP INDEX
+// ---------------------------------------------------------------------------
+
+/// `DROP INDEX name [ON table]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DropIndexStatement {
+    /// Source span of the entire statement.
+    pub span: Span,
+    /// `IF EXISTS` guard.
+    pub if_exists: bool,
+    /// Index name.
+    pub name: Identifier,
+    /// Optional table qualifier (some dialects require `ON table`).
+    pub table: Option<QualifiedName>,
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::ast::{ComparisonOperator, Literal};
+
+    fn ident(s: &str) -> Identifier {
+        Identifier::new(s.to_string())
+    }
+
+    fn qualified(s: &str) -> QualifiedName {
+        QualifiedName::new(None, s.to_string())
+    }
+
+    // ===== ColumnDef / ColumnConstraint =====
+
+    #[test]
+    fn column_def_basic() {
+        let col = ColumnDef {
+            span: Span::new(0, 10),
+            name: ident("id"),
+            data_type: DataType::BigInt,
+            nullable: false,
+            default: None,
+            constraints: vec![ColumnConstraint::PrimaryKey],
+        };
+        assert_eq!(col.name.value(), "id");
+        assert!(!col.nullable);
+        assert_eq!(col.constraints.len(), 1);
+    }
+
+    #[test]
+    fn column_def_nullable_default_is_true() {
+        let col = ColumnDef {
+            span: Span::new(0, 5),
+            name: ident("email"),
+            data_type: DataType::VarChar { length: Some(255) },
+            nullable: true,
+            default: None,
+            constraints: vec![],
+        };
+        assert!(col.nullable);
+    }
+
+    #[test]
+    fn column_def_with_default_and_constraints() {
+        let col = ColumnDef {
+            span: Span::new(0, 20),
+            name: ident("status"),
+            data_type: DataType::Int,
+            nullable: false,
+            default: Some(Expression::Literal(Literal::Integer(0))),
+            constraints: vec![ColumnConstraint::Unique, ColumnConstraint::AutoIncrement],
+        };
+        assert!(col.default.is_some());
+        assert_eq!(col.constraints.len(), 2);
+    }
+
+    #[test]
+    fn column_constraint_references() {
+        let c = ColumnConstraint::References {
+            table: qualified("users"),
+            columns: vec!["id".to_string()],
+        };
+        if let ColumnConstraint::References { table, columns } = &c {
+            assert_eq!(table.name(), "users");
+            assert_eq!(columns.len(), 1);
+        } else {
+            panic!("expected References");
+        }
+    }
+
+    #[test]
+    fn column_constraint_check_carries_expression() {
+        let c = ColumnConstraint::Check(Expression::Comparison {
+            left: Box::new(Expression::Identifier(ident("age"))),
+            op: ComparisonOperator::Ge,
+            right: Box::new(Expression::Literal(Literal::Integer(18))),
+        });
+        assert!(matches!(c, ColumnConstraint::Check(_)));
+    }
+
+    #[test]
+    fn column_constraint_clone_equality() {
+        let c = ColumnConstraint::PrimaryKey;
+        assert_eq!(c, c.clone());
+    }
+
+    #[test]
+    fn column_def_clone_equality() {
+        let col = ColumnDef {
+            span: Span::new(0, 10),
+            name: ident("id"),
+            data_type: DataType::Int,
+            nullable: false,
+            default: None,
+            constraints: vec![ColumnConstraint::PrimaryKey],
+        };
+        assert_eq!(col, col.clone());
+    }
+
+    // ===== TableConstraint =====
+
+    #[test]
+    fn table_constraint_primary_key_with_columns() {
+        let tc = TableConstraint::PrimaryKey {
+            name: Some("pk_users".to_string()),
+            columns: vec![ident("id")],
+        };
+        if let TableConstraint::PrimaryKey { name, columns } = &tc {
+            assert_eq!(name.as_ref().unwrap(), "pk_users");
+            assert_eq!(columns.len(), 1);
+        } else {
+            panic!("expected PrimaryKey");
+        }
+    }
+
+    #[test]
+    fn table_constraint_unique_unnamed() {
+        let tc = TableConstraint::Unique {
+            name: None,
+            columns: vec![ident("email")],
+        };
+        if let TableConstraint::Unique { name, columns } = &tc {
+            assert!(name.is_none());
+            assert_eq!(columns.len(), 1);
+        } else {
+            panic!("expected Unique");
+        }
+    }
+
+    #[test]
+    fn table_constraint_foreign_key_full() {
+        let tc = TableConstraint::ForeignKey {
+            name: Some("fk_order_user".to_string()),
+            columns: vec![ident("user_id")],
+            ref_table: qualified("users"),
+            ref_columns: vec![ident("id")],
+        };
+        if let TableConstraint::ForeignKey {
+            ref_table,
+            ref_columns,
+            ..
+        } = &tc
+        {
+            assert_eq!(ref_table.name(), "users");
+            assert_eq!(ref_columns.len(), 1);
+        } else {
+            panic!("expected ForeignKey");
+        }
+    }
+
+    #[test]
+    fn table_constraint_check() {
+        let tc = TableConstraint::Check {
+            name: None,
+            expr: Expression::Comparison {
+                left: Box::new(Expression::Identifier(ident("total"))),
+                op: ComparisonOperator::Ge,
+                right: Box::new(Expression::Literal(Literal::Integer(0))),
+            },
+        };
+        assert!(matches!(tc, TableConstraint::Check { .. }));
+    }
+
+    #[test]
+    fn table_constraint_clone_equality() {
+        let tc = TableConstraint::PrimaryKey {
+            name: Some("pk".to_string()),
+            columns: vec![ident("id")],
+        };
+        assert_eq!(tc, tc.clone());
+    }
+
+    // ===== TableOptions =====
+
+    #[test]
+    fn table_options_default_all_none() {
+        let opts = TableOptions::default();
+        assert!(opts.engine.is_none());
+        assert!(opts.charset.is_none());
+        assert!(opts.collation.is_none());
+        assert!(opts.comment.is_none());
+    }
+
+    #[test]
+    fn table_options_mysql_engine_and_charset() {
+        let opts = TableOptions {
+            engine: Some("InnoDB".to_string()),
+            charset: Some("utf8mb4".to_string()),
+            collation: Some("utf8mb4_unicode_ci".to_string()),
+            comment: Some("user table".to_string()),
+        };
+        assert_eq!(opts.engine.as_ref().unwrap(), "InnoDB");
+        assert_eq!(opts.charset.as_ref().unwrap(), "utf8mb4");
+    }
+
+    // ===== CreateTableStatement =====
+
+    #[test]
+    fn create_table_basic() {
+        let stmt = CreateTableStatement {
+            span: Span::new(0, 100),
+            if_not_exists: false,
+            temporary: false,
+            name: qualified("users"),
+            columns: vec![ColumnDef {
+                span: Span::new(0, 10),
+                name: ident("id"),
+                data_type: DataType::BigInt,
+                nullable: false,
+                default: None,
+                constraints: vec![ColumnConstraint::PrimaryKey],
+            }],
+            constraints: vec![],
+            options: TableOptions::default(),
+        };
+        assert_eq!(stmt.columns.len(), 1);
+        assert!(!stmt.if_not_exists);
+        assert!(!stmt.temporary);
+    }
+
+    #[test]
+    fn create_table_if_not_exists_temporary_with_constraint() {
+        let stmt = CreateTableStatement {
+            span: Span::new(0, 50),
+            if_not_exists: true,
+            temporary: true,
+            name: QualifiedName::new(Some("tempdb".to_string()), "t".to_string()),
+            columns: vec![],
+            constraints: vec![TableConstraint::PrimaryKey {
+                name: None,
+                columns: vec![ident("id")],
+            }],
+            options: TableOptions {
+                engine: Some("InnoDB".to_string()),
+                charset: None,
+                collation: None,
+                comment: None,
+            },
+        };
+        assert!(stmt.if_not_exists);
+        assert!(stmt.temporary);
+        assert_eq!(stmt.name.schema(), Some("tempdb"));
+        assert_eq!(stmt.constraints.len(), 1);
+    }
+
+    #[test]
+    fn create_table_clone_equality() {
+        let stmt = CreateTableStatement {
+            span: Span::new(0, 10),
+            if_not_exists: false,
+            temporary: false,
+            name: qualified("t"),
+            columns: vec![ColumnDef {
+                span: Span::new(0, 5),
+                name: ident("c"),
+                data_type: DataType::Int,
+                nullable: true,
+                default: None,
+                constraints: vec![],
+            }],
+            constraints: vec![],
+            options: TableOptions::default(),
+        };
+        assert_eq!(stmt, stmt.clone());
+    }
+
+    // ===== AlterTableStatement / AlterTableAction =====
+
+    #[test]
+    fn alter_table_add_column() {
+        let stmt = AlterTableStatement {
+            span: Span::new(0, 30),
+            name: qualified("users"),
+            actions: vec![AlterTableAction::AddColumn(ColumnDef {
+                span: Span::new(10, 30),
+                name: ident("email"),
+                data_type: DataType::VarChar { length: Some(255) },
+                nullable: true,
+                default: None,
+                constraints: vec![],
+            })],
+        };
+        assert_eq!(stmt.actions.len(), 1);
+        assert!(matches!(stmt.actions[0], AlterTableAction::AddColumn(_)));
+    }
+
+    #[test]
+    fn alter_table_drop_column() {
+        let stmt = AlterTableStatement {
+            span: Span::new(0, 20),
+            name: qualified("users"),
+            actions: vec![AlterTableAction::DropColumn(ident("email"))],
+        };
+        assert!(matches!(stmt.actions[0], AlterTableAction::DropColumn(_)));
+    }
+
+    #[test]
+    fn alter_table_alter_column_type() {
+        let stmt = AlterTableStatement {
+            span: Span::new(0, 20),
+            name: qualified("users"),
+            actions: vec![AlterTableAction::AlterColumn {
+                column: ident("name"),
+                data_type: Some(DataType::VarChar { length: Some(200) }),
+                default: None,
+                nullable: None,
+            }],
+        };
+        if let AlterTableAction::AlterColumn {
+            column, data_type, ..
+        } = &stmt.actions[0]
+        {
+            assert_eq!(column.value(), "name");
+            assert!(data_type.is_some());
+        } else {
+            panic!("expected AlterColumn");
+        }
+    }
+
+    #[test]
+    fn alter_table_add_constraint_and_drop_constraint() {
+        let stmt = AlterTableStatement {
+            span: Span::new(0, 60),
+            name: qualified("users"),
+            actions: vec![
+                AlterTableAction::AddConstraint(TableConstraint::Unique {
+                    name: Some("uk_email".to_string()),
+                    columns: vec![ident("email")],
+                }),
+                AlterTableAction::DropConstraint("uk_email".to_string()),
+            ],
+        };
+        assert_eq!(stmt.actions.len(), 2);
+        assert!(matches!(
+            stmt.actions[0],
+            AlterTableAction::AddConstraint(_)
+        ));
+        assert!(matches!(
+            stmt.actions[1],
+            AlterTableAction::DropConstraint(_)
+        ));
+    }
+
+    #[test]
+    fn alter_table_rename_to() {
+        let stmt = AlterTableStatement {
+            span: Span::new(0, 20),
+            name: qualified("old"),
+            actions: vec![AlterTableAction::RenameTo(qualified("new"))],
+        };
+        if let AlterTableAction::RenameTo(new) = &stmt.actions[0] {
+            assert_eq!(new.name(), "new");
+        } else {
+            panic!("expected RenameTo");
+        }
+    }
+
+    #[test]
+    fn alter_table_clone_equality() {
+        let stmt = AlterTableStatement {
+            span: Span::new(0, 10),
+            name: qualified("t"),
+            actions: vec![AlterTableAction::DropColumn(ident("c"))],
+        };
+        assert_eq!(stmt, stmt.clone());
+    }
+
+    // ===== DropTableStatement =====
+
+    #[test]
+    fn drop_table_single() {
+        let stmt = DropTableStatement {
+            span: Span::new(0, 20),
+            if_exists: false,
+            names: vec![qualified("users")],
+        };
+        assert_eq!(stmt.names.len(), 1);
+        assert!(!stmt.if_exists);
+    }
+
+    #[test]
+    fn drop_table_if_exists_multiple() {
+        let stmt = DropTableStatement {
+            span: Span::new(0, 40),
+            if_exists: true,
+            names: vec![qualified("a"), qualified("b")],
+        };
+        assert!(stmt.if_exists);
+        assert_eq!(stmt.names.len(), 2);
+    }
+
+    #[test]
+    fn drop_table_clone_equality() {
+        let stmt = DropTableStatement {
+            span: Span::new(0, 10),
+            if_exists: false,
+            names: vec![qualified("t")],
+        };
+        assert_eq!(stmt, stmt.clone());
+    }
+
+    // ===== CreateIndexStatement / IndexColumn / SortDirection =====
+
+    #[test]
+    fn create_index_basic() {
+        let stmt = CreateIndexStatement {
+            span: Span::new(0, 40),
+            unique: false,
+            if_not_exists: false,
+            name: ident("idx_name"),
+            table: qualified("users"),
+            columns: vec![IndexColumn {
+                name: ident("name"),
+                direction: None,
+            }],
+        };
+        assert_eq!(stmt.name.value(), "idx_name");
+        assert!(!stmt.unique);
+        assert_eq!(stmt.columns.len(), 1);
+    }
+
+    #[test]
+    fn create_index_unique_with_direction() {
+        let stmt = CreateIndexStatement {
+            span: Span::new(0, 50),
+            unique: true,
+            if_not_exists: false,
+            name: ident("uk_email"),
+            table: qualified("users"),
+            columns: vec![IndexColumn {
+                name: ident("email"),
+                direction: Some(SortDirection::Desc),
+            }],
+        };
+        assert!(stmt.unique);
+        assert_eq!(stmt.columns[0].direction, Some(SortDirection::Desc));
+    }
+
+    #[test]
+    fn create_index_multi_column() {
+        let stmt = CreateIndexStatement {
+            span: Span::new(0, 60),
+            unique: false,
+            if_not_exists: true,
+            name: ident("idx_last_first"),
+            table: qualified("users"),
+            columns: vec![
+                IndexColumn {
+                    name: ident("last"),
+                    direction: Some(SortDirection::Asc),
+                },
+                IndexColumn {
+                    name: ident("first"),
+                    direction: None,
+                },
+            ],
+        };
+        assert!(stmt.if_not_exists);
+        assert_eq!(stmt.columns.len(), 2);
+    }
+
+    #[test]
+    fn create_index_clone_equality() {
+        let stmt = CreateIndexStatement {
+            span: Span::new(0, 10),
+            unique: false,
+            if_not_exists: false,
+            name: ident("i"),
+            table: qualified("t"),
+            columns: vec![IndexColumn {
+                name: ident("c"),
+                direction: None,
+            }],
+        };
+        assert_eq!(stmt, stmt.clone());
+    }
+
+    #[test]
+    fn sort_direction_copy_equality() {
+        let asc = SortDirection::Asc;
+        let copied = asc;
+        assert_eq!(asc, copied);
+        assert_ne!(SortDirection::Asc, SortDirection::Desc);
+    }
+
+    // ===== DropIndexStatement =====
+
+    #[test]
+    fn drop_index_basic() {
+        let stmt = DropIndexStatement {
+            span: Span::new(0, 20),
+            if_exists: false,
+            name: ident("idx_name"),
+            table: Some(qualified("users")),
+        };
+        assert_eq!(stmt.name.value(), "idx_name");
+        assert!(stmt.table.is_some());
+    }
+
+    #[test]
+    fn drop_index_if_exists_no_table() {
+        let stmt = DropIndexStatement {
+            span: Span::new(0, 15),
+            if_exists: true,
+            name: ident("idx"),
+            table: None,
+        };
+        assert!(stmt.if_exists);
+        assert!(stmt.table.is_none());
+    }
+
+    #[test]
+    fn drop_index_clone_equality() {
+        let stmt = DropIndexStatement {
+            span: Span::new(0, 10),
+            if_exists: false,
+            name: ident("i"),
+            table: Some(qualified("t")),
+        };
+        assert_eq!(stmt, stmt.clone());
+    }
+
+    // ===== Debug output spot checks =====
+
+    #[test]
+    fn debug_output_create_table() {
+        let stmt = CreateTableStatement {
+            span: Span::new(0, 1),
+            if_not_exists: false,
+            temporary: false,
+            name: qualified("t"),
+            columns: vec![],
+            constraints: vec![],
+            options: TableOptions::default(),
+        };
+        let s = format!("{stmt:?}");
+        assert!(s.contains("CreateTableStatement"));
+    }
+
+    #[test]
+    fn debug_output_alter_table_action_variants() {
+        let a = AlterTableAction::DropColumn(ident("c"));
+        let s = format!("{a:?}");
+        assert!(s.contains("DropColumn"));
+    }
+}

--- a/crates/common-sql/src/ast/ddl.rs
+++ b/crates/common-sql/src/ast/ddl.rs
@@ -207,7 +207,7 @@ pub struct IndexColumn {
     pub name: Identifier,
     /// Sort direction (`ASC` / `DESC`); `None` means default.
     ///
-    /// Reuses [`SortDirection`](crate::ast::clause::SortDirection) so that
+    /// Reuses [`SortDirection`] so that
     /// index columns and `ORDER BY` items share one canonical type.
     pub direction: Option<SortDirection>,
 }

--- a/crates/common-sql/src/ast/expression.rs
+++ b/crates/common-sql/src/ast/expression.rs
@@ -1,0 +1,800 @@
+//! SQL expression nodes.
+//!
+//! Covers literals, identifiers, operators, function calls, CASE expressions,
+//! subqueries, EXISTS, IN, BETWEEN, CAST, and IS NULL.
+
+use crate::ast::datatype::DataType;
+use crate::ast::identifier::Identifier;
+use crate::ast::literal::Literal;
+use crate::ast::statement::SelectStatement;
+
+// ---------------------------------------------------------------------------
+// Operator enums (Task 3.1)
+// ---------------------------------------------------------------------------
+
+/// Binary arithmetic / string operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BinaryOperator {
+    /// Addition (`+`).
+    Add,
+    /// Subtraction (`-`).
+    Sub,
+    /// Multiplication (`*`).
+    Mul,
+    /// Division (`/`).
+    Div,
+    /// Modulo (`%`).
+    Mod,
+    /// String concatenation (`||`).
+    Concat,
+}
+
+/// Unary prefix operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UnaryOperator {
+    /// Positive sign (`+expr`).
+    Plus,
+    /// Negative sign (`-expr`).
+    Minus,
+    /// Logical negation (`NOT expr`).
+    Not,
+}
+
+/// Logical connective operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LogicalOperator {
+    /// Logical AND.
+    And,
+    /// Logical OR.
+    Or,
+}
+
+/// Comparison operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ComparisonOperator {
+    /// Equal (`=`).
+    Eq,
+    /// Not equal (`!=` / `<>`).
+    Ne,
+    /// Less than (`<`).
+    Lt,
+    /// Less than or equal (`<=`).
+    Le,
+    /// Greater than (`>`).
+    Gt,
+    /// Greater than or equal (`>=`).
+    Ge,
+    /// Pattern match (`LIKE`).
+    Like,
+    /// Negated pattern match (`NOT LIKE`).
+    NotLike,
+    /// Case-insensitive pattern match (`ILIKE` — PostgreSQL).
+    ILike,
+    /// Negated case-insensitive pattern match (`NOT ILIKE`).
+    NotILike,
+}
+
+// ---------------------------------------------------------------------------
+// InList (Task 3.2)
+// ---------------------------------------------------------------------------
+
+/// The right-hand side of an `IN` expression.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InList {
+    /// Explicit value list: `expr IN (1, 2, 3)`.
+    Values(Vec<Expression>),
+    /// Subquery: `expr IN (SELECT ...)`.
+    Subquery(Box<SelectStatement>),
+}
+
+// ---------------------------------------------------------------------------
+// Expression (Tasks 2.3 + 3.1 + 3.2)
+// ---------------------------------------------------------------------------
+
+/// A SQL expression.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expression {
+    // ----- Task 2.3: basic nodes -----
+    /// A literal value.
+    Literal(Literal),
+    /// A simple identifier.
+    Identifier(Identifier),
+    /// A schema-qualified identifier (`table.column`).
+    QualifiedIdentifier {
+        /// Table or schema qualifier.
+        table: Identifier,
+        /// Column name.
+        column: Identifier,
+    },
+
+    // ----- Task 3.1: operator nodes -----
+    /// Binary arithmetic / string operation.
+    BinaryOp {
+        /// Left-hand side.
+        left: Box<Expression>,
+        /// The operator.
+        op: BinaryOperator,
+        /// Right-hand side.
+        right: Box<Expression>,
+    },
+    /// Unary prefix operation.
+    UnaryOp {
+        /// The operator.
+        op: UnaryOperator,
+        /// The operand.
+        expr: Box<Expression>,
+    },
+    /// Logical connective.
+    LogicalOp {
+        /// Left-hand side.
+        left: Box<Expression>,
+        /// The operator.
+        op: LogicalOperator,
+        /// Right-hand side.
+        right: Box<Expression>,
+    },
+    /// Comparison expression.
+    Comparison {
+        /// Left-hand side.
+        left: Box<Expression>,
+        /// The operator.
+        op: ComparisonOperator,
+        /// Right-hand side.
+        right: Box<Expression>,
+    },
+
+    // ----- Task 3.2: advanced nodes -----
+    /// Function call: `name([DISTINCT] args...)`.
+    Function {
+        /// Function name.
+        name: Identifier,
+        /// Argument list.
+        args: Vec<Expression>,
+        /// Whether `DISTINCT` was specified.
+        distinct: bool,
+    },
+    /// CASE expression.
+    Case {
+        /// Optional CASE operand (simple CASE).
+        operand: Option<Box<Expression>>,
+        /// `(when, then)` pairs.
+        conditions: Vec<(Expression, Expression)>,
+        /// ELSE result.
+        else_result: Option<Box<Expression>>,
+    },
+    /// Scalar subquery: `(SELECT ...)`.
+    Subquery(Box<SelectStatement>),
+    /// `EXISTS (SELECT ...)` / `NOT EXISTS (SELECT ...)`.
+    Exists {
+        /// The subquery.
+        subquery: Box<SelectStatement>,
+        /// `true` for `NOT EXISTS`.
+        negated: bool,
+    },
+    /// `expr IN (list)` / `expr NOT IN (list)`.
+    In {
+        /// The expression before `IN`.
+        expr: Box<Expression>,
+        /// Value list or subquery.
+        list: InList,
+        /// `true` for `NOT IN`.
+        negated: bool,
+    },
+    /// `expr BETWEEN low AND high` / `expr NOT BETWEEN low AND high`.
+    Between {
+        /// The expression before `BETWEEN`.
+        expr: Box<Expression>,
+        /// Lower bound.
+        low: Box<Expression>,
+        /// Upper bound.
+        high: Box<Expression>,
+        /// `true` for `NOT BETWEEN`.
+        negated: bool,
+    },
+    /// `CAST(expr AS data_type)`.
+    Cast {
+        /// The expression to cast.
+        expr: Box<Expression>,
+        /// Target data type.
+        data_type: DataType,
+    },
+    /// `expr IS NULL` / `expr IS NOT NULL`.
+    IsNull {
+        /// The expression to test.
+        expr: Box<Expression>,
+        /// `true` for `IS NOT NULL`.
+        negated: bool,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::ast::SelectItem;
+
+    // ===== Task 2.3: basic expression tests =====
+
+    #[test]
+    fn literal_expression() {
+        let expr = Expression::Literal(Literal::Integer(42));
+        assert!(matches!(expr, Expression::Literal(Literal::Integer(42))));
+    }
+
+    #[test]
+    fn identifier_expression() {
+        let expr = Expression::Identifier(Identifier::new("col".to_string()));
+        assert!(matches!(expr, Expression::Identifier(_)));
+    }
+
+    #[test]
+    fn qualified_identifier_expression() {
+        let expr = Expression::QualifiedIdentifier {
+            table: Identifier::new("t".to_string()),
+            column: Identifier::new("c".to_string()),
+        };
+        assert!(matches!(expr, Expression::QualifiedIdentifier { .. }));
+    }
+
+    // ===== Task 3.1: operator expression tests =====
+
+    #[test]
+    fn binary_op_expression() {
+        let expr = Expression::BinaryOp {
+            left: Box::new(Expression::Literal(Literal::Integer(1))),
+            op: BinaryOperator::Add,
+            right: Box::new(Expression::Literal(Literal::Integer(2))),
+        };
+        if let Expression::BinaryOp { op, .. } = &expr {
+            assert_eq!(*op, BinaryOperator::Add);
+        } else {
+            panic!("expected BinaryOp");
+        }
+    }
+
+    #[test]
+    fn unary_op_expression() {
+        let expr = Expression::UnaryOp {
+            op: UnaryOperator::Minus,
+            expr: Box::new(Expression::Literal(Literal::Integer(5))),
+        };
+        if let Expression::UnaryOp { op, .. } = &expr {
+            assert_eq!(*op, UnaryOperator::Minus);
+        } else {
+            panic!("expected UnaryOp");
+        }
+    }
+
+    #[test]
+    fn logical_op_expression() {
+        let expr = Expression::LogicalOp {
+            left: Box::new(Expression::Literal(Literal::Boolean(true))),
+            op: LogicalOperator::And,
+            right: Box::new(Expression::Literal(Literal::Boolean(false))),
+        };
+        if let Expression::LogicalOp { op, .. } = &expr {
+            assert_eq!(*op, LogicalOperator::And);
+        } else {
+            panic!("expected LogicalOp");
+        }
+    }
+
+    #[test]
+    fn comparison_expression() {
+        let expr = Expression::Comparison {
+            left: Box::new(Expression::Identifier(Identifier::new("x".to_string()))),
+            op: ComparisonOperator::Eq,
+            right: Box::new(Expression::Literal(Literal::Integer(1))),
+        };
+        if let Expression::Comparison { op, .. } = &expr {
+            assert_eq!(*op, ComparisonOperator::Eq);
+        } else {
+            panic!("expected Comparison");
+        }
+    }
+
+    #[test]
+    fn nested_binary_op() {
+        // (1 + 2) * 3
+        let inner = Expression::BinaryOp {
+            left: Box::new(Expression::Literal(Literal::Integer(1))),
+            op: BinaryOperator::Add,
+            right: Box::new(Expression::Literal(Literal::Integer(2))),
+        };
+        let outer = Expression::BinaryOp {
+            left: Box::new(inner),
+            op: BinaryOperator::Mul,
+            right: Box::new(Expression::Literal(Literal::Integer(3))),
+        };
+        if let Expression::BinaryOp { op, .. } = &outer {
+            assert_eq!(*op, BinaryOperator::Mul);
+        } else {
+            panic!("expected BinaryOp");
+        }
+    }
+
+    // ===== Task 3.2: advanced expression tests =====
+
+    // --- Function ---
+
+    #[test]
+    fn function_call_basic() {
+        let expr = Expression::Function {
+            name: Identifier::new("COUNT".to_string()),
+            args: vec![Expression::Identifier(Identifier::new("id".to_string()))],
+            distinct: false,
+        };
+        if let Expression::Function {
+            name,
+            args,
+            distinct,
+        } = &expr
+        {
+            assert_eq!(name.value(), "COUNT");
+            assert_eq!(args.len(), 1);
+            assert!(!distinct);
+        } else {
+            panic!("expected Function");
+        }
+    }
+
+    #[test]
+    fn function_call_distinct() {
+        let expr = Expression::Function {
+            name: Identifier::new("SUM".to_string()),
+            args: vec![Expression::Identifier(Identifier::new(
+                "salary".to_string(),
+            ))],
+            distinct: true,
+        };
+        if let Expression::Function { distinct, .. } = &expr {
+            assert!(distinct);
+        } else {
+            panic!("expected Function");
+        }
+    }
+
+    #[test]
+    fn function_call_no_args() {
+        let expr = Expression::Function {
+            name: Identifier::new("NOW".to_string()),
+            args: vec![],
+            distinct: false,
+        };
+        if let Expression::Function { args, .. } = &expr {
+            assert!(args.is_empty());
+        } else {
+            panic!("expected Function");
+        }
+    }
+
+    #[test]
+    fn function_call_multiple_args() {
+        let expr = Expression::Function {
+            name: Identifier::new("COALESCE".to_string()),
+            args: vec![
+                Expression::Identifier(Identifier::new("a".to_string())),
+                Expression::Identifier(Identifier::new("b".to_string())),
+                Expression::Literal(Literal::Null),
+            ],
+            distinct: false,
+        };
+        if let Expression::Function { args, .. } = &expr {
+            assert_eq!(args.len(), 3);
+        } else {
+            panic!("expected Function");
+        }
+    }
+
+    // --- CASE ---
+
+    #[test]
+    fn case_simple() {
+        // CASE x WHEN 1 THEN 'one' WHEN 2 THEN 'two' ELSE 'other' END
+        let expr = Expression::Case {
+            operand: Some(Box::new(Expression::Identifier(Identifier::new(
+                "x".to_string(),
+            )))),
+            conditions: vec![
+                (
+                    Expression::Literal(Literal::Integer(1)),
+                    Expression::Literal(Literal::String("one".to_string())),
+                ),
+                (
+                    Expression::Literal(Literal::Integer(2)),
+                    Expression::Literal(Literal::String("two".to_string())),
+                ),
+            ],
+            else_result: Some(Box::new(Expression::Literal(Literal::String(
+                "other".to_string(),
+            )))),
+        };
+        if let Expression::Case {
+            operand,
+            conditions,
+            else_result,
+        } = &expr
+        {
+            assert!(operand.is_some());
+            assert_eq!(conditions.len(), 2);
+            assert!(else_result.is_some());
+        } else {
+            panic!("expected Case");
+        }
+    }
+
+    #[test]
+    fn case_searched() {
+        // CASE WHEN x > 0 THEN 'pos' WHEN x < 0 THEN 'neg' END
+        let expr = Expression::Case {
+            operand: None,
+            conditions: vec![(
+                Expression::Comparison {
+                    left: Box::new(Expression::Identifier(Identifier::new("x".to_string()))),
+                    op: ComparisonOperator::Gt,
+                    right: Box::new(Expression::Literal(Literal::Integer(0))),
+                },
+                Expression::Literal(Literal::String("pos".to_string())),
+            )],
+            else_result: None,
+        };
+        if let Expression::Case {
+            operand,
+            conditions,
+            else_result,
+        } = &expr
+        {
+            assert!(operand.is_none());
+            assert_eq!(conditions.len(), 1);
+            assert!(else_result.is_none());
+        } else {
+            panic!("expected Case");
+        }
+    }
+
+    // --- Subquery ---
+
+    #[test]
+    fn subquery_expression() {
+        let sel = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        let expr = Expression::Subquery(Box::new(sel));
+        assert!(matches!(expr, Expression::Subquery(_)));
+    }
+
+    #[test]
+    fn subquery_in_select_list() {
+        // SELECT (SELECT MAX(id) FROM t) AS max_id
+        let sub = Expression::Subquery(Box::new(SelectStatement::simple(vec![
+            SelectItem::Expression {
+                expr: Expression::Function {
+                    name: Identifier::new("MAX".to_string()),
+                    args: vec![Expression::Identifier(Identifier::new("id".to_string()))],
+                    distinct: false,
+                },
+                alias: None,
+            },
+        ])));
+        assert!(matches!(sub, Expression::Subquery(_)));
+    }
+
+    // --- EXISTS ---
+
+    #[test]
+    fn exists_expression() {
+        let sel = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        let expr = Expression::Exists {
+            subquery: Box::new(sel),
+            negated: false,
+        };
+        if let Expression::Exists { negated, .. } = &expr {
+            assert!(!negated);
+        } else {
+            panic!("expected Exists");
+        }
+    }
+
+    #[test]
+    fn not_exists_expression() {
+        let sel = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        let expr = Expression::Exists {
+            subquery: Box::new(sel),
+            negated: true,
+        };
+        if let Expression::Exists { negated, .. } = &expr {
+            assert!(negated);
+        } else {
+            panic!("expected Exists");
+        }
+    }
+
+    // --- IN ---
+
+    #[test]
+    fn in_values_expression() {
+        let expr = Expression::In {
+            expr: Box::new(Expression::Identifier(Identifier::new(
+                "status".to_string(),
+            ))),
+            list: InList::Values(vec![
+                Expression::Literal(Literal::String("active".to_string())),
+                Expression::Literal(Literal::String("pending".to_string())),
+            ]),
+            negated: false,
+        };
+        if let Expression::In { list, negated, .. } = &expr {
+            assert!(!negated);
+            if let InList::Values(vals) = list {
+                assert_eq!(vals.len(), 2);
+            } else {
+                panic!("expected InList::Values");
+            }
+        } else {
+            panic!("expected In");
+        }
+    }
+
+    #[test]
+    fn not_in_values_expression() {
+        let expr = Expression::In {
+            expr: Box::new(Expression::Identifier(Identifier::new("id".to_string()))),
+            list: InList::Values(vec![Expression::Literal(Literal::Integer(1))]),
+            negated: true,
+        };
+        if let Expression::In { negated, .. } = &expr {
+            assert!(negated);
+        } else {
+            panic!("expected In");
+        }
+    }
+
+    #[test]
+    fn in_subquery_expression() {
+        let sel = SelectStatement::simple(vec![SelectItem::Expression {
+            expr: Expression::Identifier(Identifier::new("id".to_string())),
+            alias: None,
+        }]);
+        let expr = Expression::In {
+            expr: Box::new(Expression::Identifier(Identifier::new(
+                "user_id".to_string(),
+            ))),
+            list: InList::Subquery(Box::new(sel)),
+            negated: false,
+        };
+        if let Expression::In { list, .. } = &expr {
+            assert!(matches!(list, InList::Subquery(_)));
+        } else {
+            panic!("expected In");
+        }
+    }
+
+    // --- BETWEEN ---
+
+    #[test]
+    fn between_expression() {
+        let expr = Expression::Between {
+            expr: Box::new(Expression::Identifier(Identifier::new("age".to_string()))),
+            low: Box::new(Expression::Literal(Literal::Integer(18))),
+            high: Box::new(Expression::Literal(Literal::Integer(65))),
+            negated: false,
+        };
+        if let Expression::Between { negated, .. } = &expr {
+            assert!(!negated);
+        } else {
+            panic!("expected Between");
+        }
+    }
+
+    #[test]
+    fn not_between_expression() {
+        let expr = Expression::Between {
+            expr: Box::new(Expression::Identifier(Identifier::new("price".to_string()))),
+            low: Box::new(Expression::Literal(Literal::Float("0.0".to_string()))),
+            high: Box::new(Expression::Literal(Literal::Float("100.0".to_string()))),
+            negated: true,
+        };
+        if let Expression::Between { negated, .. } = &expr {
+            assert!(negated);
+        } else {
+            panic!("expected Between");
+        }
+    }
+
+    // --- CAST ---
+
+    #[test]
+    fn cast_expression() {
+        let expr = Expression::Cast {
+            expr: Box::new(Expression::Identifier(Identifier::new("price".to_string()))),
+            data_type: DataType::Decimal {
+                precision: Some(18),
+                scale: Some(4),
+            },
+        };
+        if let Expression::Cast { data_type, .. } = &expr {
+            assert_eq!(
+                *data_type,
+                DataType::Decimal {
+                    precision: Some(18),
+                    scale: Some(4),
+                }
+            );
+        } else {
+            panic!("expected Cast");
+        }
+    }
+
+    #[test]
+    fn cast_to_varchar() {
+        let expr = Expression::Cast {
+            expr: Box::new(Expression::Literal(Literal::Integer(123))),
+            data_type: DataType::VarChar { length: Some(50) },
+        };
+        if let Expression::Cast { data_type, .. } = &expr {
+            assert_eq!(*data_type, DataType::VarChar { length: Some(50) });
+        } else {
+            panic!("expected Cast");
+        }
+    }
+
+    // --- IS NULL ---
+
+    #[test]
+    fn is_null_expression() {
+        let expr = Expression::IsNull {
+            expr: Box::new(Expression::Identifier(Identifier::new("email".to_string()))),
+            negated: false,
+        };
+        if let Expression::IsNull { negated, .. } = &expr {
+            assert!(!negated);
+        } else {
+            panic!("expected IsNull");
+        }
+    }
+
+    #[test]
+    fn is_not_null_expression() {
+        let expr = Expression::IsNull {
+            expr: Box::new(Expression::Identifier(Identifier::new("name".to_string()))),
+            negated: true,
+        };
+        if let Expression::IsNull { negated, .. } = &expr {
+            assert!(negated);
+        } else {
+            panic!("expected IsNull");
+        }
+    }
+
+    // ===== Cross-cutting: equality and clone =====
+
+    #[test]
+    fn expression_equality() {
+        let a = Expression::Literal(Literal::Integer(1));
+        let b = Expression::Literal(Literal::Integer(1));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn expression_inequality() {
+        let a = Expression::Literal(Literal::Integer(1));
+        let b = Expression::Literal(Literal::Integer(2));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn expression_clone() {
+        let expr = Expression::Function {
+            name: Identifier::new("COUNT".to_string()),
+            args: vec![Expression::Literal(Literal::Integer(1))],
+            distinct: true,
+        };
+        let cloned = expr.clone();
+        assert_eq!(expr, cloned);
+    }
+
+    #[test]
+    fn complex_nested_expression() {
+        // (a + b) > 0 AND EXISTS (SELECT 1) AND x IS NOT NULL
+        let inner = Expression::BinaryOp {
+            left: Box::new(Expression::Identifier(Identifier::new("a".to_string()))),
+            op: BinaryOperator::Add,
+            right: Box::new(Expression::Identifier(Identifier::new("b".to_string()))),
+        };
+        let cmp = Expression::Comparison {
+            left: Box::new(inner),
+            op: ComparisonOperator::Gt,
+            right: Box::new(Expression::Literal(Literal::Integer(0))),
+        };
+        let exists = Expression::Exists {
+            subquery: Box::new(SelectStatement::simple(vec![SelectItem::Expression {
+                expr: Expression::Literal(Literal::Integer(1)),
+                alias: None,
+            }])),
+            negated: false,
+        };
+        let is_not_null = Expression::IsNull {
+            expr: Box::new(Expression::Identifier(Identifier::new("x".to_string()))),
+            negated: true,
+        };
+        let and1 = Expression::LogicalOp {
+            left: Box::new(cmp),
+            op: LogicalOperator::And,
+            right: Box::new(exists),
+        };
+        let full = Expression::LogicalOp {
+            left: Box::new(and1),
+            op: LogicalOperator::And,
+            right: Box::new(is_not_null),
+        };
+        // Verify the full tree is a LogicalOp::And
+        if let Expression::LogicalOp { op, .. } = &full {
+            assert_eq!(*op, LogicalOperator::And);
+        } else {
+            panic!("expected LogicalOp");
+        }
+    }
+
+    // ===== Operator enum tests =====
+
+    #[test]
+    fn all_binary_operators_are_copy() {
+        let ops = [
+            BinaryOperator::Add,
+            BinaryOperator::Sub,
+            BinaryOperator::Mul,
+            BinaryOperator::Div,
+            BinaryOperator::Mod,
+            BinaryOperator::Concat,
+        ];
+        for op in ops {
+            let copied = op;
+            assert_eq!(op, copied);
+        }
+    }
+
+    #[test]
+    fn all_comparison_operators_are_copy() {
+        let ops = [
+            ComparisonOperator::Eq,
+            ComparisonOperator::Ne,
+            ComparisonOperator::Lt,
+            ComparisonOperator::Le,
+            ComparisonOperator::Gt,
+            ComparisonOperator::Ge,
+            ComparisonOperator::Like,
+            ComparisonOperator::NotLike,
+            ComparisonOperator::ILike,
+            ComparisonOperator::NotILike,
+        ];
+        for op in ops {
+            let copied = op;
+            assert_eq!(op, copied);
+        }
+    }
+
+    #[test]
+    fn in_list_values_equality() {
+        let a = InList::Values(vec![
+            Expression::Literal(Literal::Integer(1)),
+            Expression::Literal(Literal::Integer(2)),
+        ]);
+        let b = InList::Values(vec![
+            Expression::Literal(Literal::Integer(1)),
+            Expression::Literal(Literal::Integer(2)),
+        ]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn in_list_subquery_clone() {
+        let sel = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        let list = InList::Subquery(Box::new(sel));
+        let cloned = list.clone();
+        assert_eq!(list, cloned);
+    }
+}

--- a/crates/common-sql/src/ast/identifier.rs
+++ b/crates/common-sql/src/ast/identifier.rs
@@ -1,0 +1,94 @@
+//! Identifier types for SQL names.
+
+/// A SQL identifier (table name, column name, alias, etc.).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Identifier {
+    value: String,
+    quoted: bool,
+}
+
+impl Identifier {
+    /// Creates a new unquoted identifier.
+    #[must_use]
+    pub fn new(value: String) -> Self {
+        Self {
+            value,
+            quoted: false,
+        }
+    }
+
+    /// Creates a new quoted identifier.
+    #[must_use]
+    pub fn new_quoted(value: String) -> Self {
+        Self {
+            value,
+            quoted: true,
+        }
+    }
+
+    /// Returns the identifier value.
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Returns `true` if this identifier was quoted in the source.
+    #[must_use]
+    pub fn quoted(&self) -> bool {
+        self.quoted
+    }
+}
+
+/// A qualified name (e.g., `schema.table`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QualifiedName {
+    schema: Option<String>,
+    name: String,
+}
+
+impl QualifiedName {
+    /// Creates a new qualified name.
+    #[must_use]
+    pub fn new(schema: Option<String>, name: String) -> Self {
+        Self { schema, name }
+    }
+
+    /// Returns the schema name, if any.
+    #[must_use]
+    pub fn schema(&self) -> Option<&str> {
+        self.schema.as_deref()
+    }
+
+    /// Returns the object name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// A table alias with optional column aliases.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TableAlias {
+    name: String,
+    columns: Vec<String>,
+}
+
+impl TableAlias {
+    /// Creates a new table alias.
+    #[must_use]
+    pub fn new(name: String, columns: Vec<String>) -> Self {
+        Self { name, columns }
+    }
+
+    /// Returns the alias name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the column aliases.
+    #[must_use]
+    pub fn columns(&self) -> &[String] {
+        &self.columns
+    }
+}

--- a/crates/common-sql/src/ast/join.rs
+++ b/crates/common-sql/src/ast/join.rs
@@ -1,0 +1,532 @@
+//! JOIN-related AST nodes.
+//!
+//! Covers join types, join conditions, table factors (table references that
+//! appear in FROM / JOIN clauses), and the `DialectHint` extension point.
+
+use crate::ast::expression::Expression;
+use crate::ast::identifier::{Identifier, QualifiedName, TableAlias};
+use crate::ast::span::Span;
+use crate::ast::statement::SelectStatement;
+
+// ---------------------------------------------------------------------------
+// JoinType
+// ---------------------------------------------------------------------------
+
+/// The kind of JOIN operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum JoinType {
+    /// `INNER JOIN` (or plain `JOIN`).
+    Inner,
+    /// `LEFT [OUTER] JOIN`.
+    Left,
+    /// `RIGHT [OUTER] JOIN`.
+    Right,
+    /// `FULL [OUTER] JOIN`.
+    Full,
+    /// `CROSS JOIN`.
+    Cross,
+}
+
+// ---------------------------------------------------------------------------
+// JoinCondition
+// ---------------------------------------------------------------------------
+
+/// The condition that follows a JOIN.
+#[derive(Debug, Clone, PartialEq)]
+pub enum JoinCondition {
+    /// `ON expression` — explicit join condition.
+    On(Expression),
+    /// `USING (col1, col2, …)` — join on shared column names.
+    Using(Vec<Identifier>),
+    /// `NATURAL JOIN` — implicit join on matching column names.
+    Natural,
+}
+
+// ---------------------------------------------------------------------------
+// TableFactor
+// ---------------------------------------------------------------------------
+
+/// A table reference that can appear in a FROM or JOIN clause.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TableFactor {
+    /// A direct table reference, optionally qualified and aliased.
+    Table {
+        /// Qualified table name (`schema.table` or just `table`).
+        name: QualifiedName,
+        /// Optional alias (`AS alias`).
+        alias: Option<TableAlias>,
+    },
+    /// A derived table (subquery in FROM clause).
+    Derived {
+        /// The subquery.
+        subquery: Box<SelectStatement>,
+        /// Optional alias — required by most dialects but modeled as optional.
+        alias: Option<TableAlias>,
+    },
+    /// A nested JOIN expression (for chained joins).
+    Join(Box<Join>),
+}
+
+// ---------------------------------------------------------------------------
+// Join
+// ---------------------------------------------------------------------------
+
+/// A single JOIN operation.
+///
+/// Represents `left [join_type] JOIN right [condition]` where the left side
+/// is implied by the position in the FROM clause or a surrounding `TableFactor::Join`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Join {
+    /// Source span of the entire JOIN clause.
+    pub span: Span,
+    /// The type of join (INNER, LEFT, RIGHT, FULL, CROSS).
+    pub join_type: JoinType,
+    /// The right-side table reference.
+    pub table: TableFactor,
+    /// The join condition (ON, USING, or NATURAL).
+    pub condition: JoinCondition,
+    /// Whether the LATERAL keyword was specified.
+    pub lateral: bool,
+}
+
+// ---------------------------------------------------------------------------
+// DialectHint
+// ---------------------------------------------------------------------------
+
+/// An opaque key-value pair for dialect-specific metadata.
+///
+/// Emitters can use this to carry extra information that does not map to any
+/// standard AST node (e.g., vendor-specific hints like `/*+ INDEX(t idx) */`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct DialectHint {
+    /// Hint key.
+    pub key: String,
+    /// Hint value.
+    pub value: String,
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::ast::{SelectItem, Span};
+
+    // ===== JoinType tests =====
+
+    #[test]
+    fn join_type_inner() {
+        let jt = JoinType::Inner;
+        assert_eq!(jt, JoinType::Inner);
+    }
+
+    #[test]
+    fn join_type_all_variants_copy() {
+        let variants = [
+            JoinType::Inner,
+            JoinType::Left,
+            JoinType::Right,
+            JoinType::Full,
+            JoinType::Cross,
+        ];
+        for v in &variants {
+            let copied = *v;
+            assert_eq!(*v, copied);
+        }
+    }
+
+    #[test]
+    fn join_type_equality() {
+        assert_eq!(JoinType::Left, JoinType::Left);
+        assert_ne!(JoinType::Left, JoinType::Right);
+    }
+
+    // ===== JoinCondition tests =====
+
+    #[test]
+    fn join_condition_on() {
+        let cond = JoinCondition::On(Expression::Comparison {
+            left: Box::new(Expression::Identifier(Identifier::new("t1.id".to_string()))),
+            op: crate::ast::ComparisonOperator::Eq,
+            right: Box::new(Expression::Identifier(Identifier::new("t2.id".to_string()))),
+        });
+        assert!(matches!(cond, JoinCondition::On(_)));
+    }
+
+    #[test]
+    fn join_condition_using() {
+        let cond = JoinCondition::Using(vec![
+            Identifier::new("id".to_string()),
+            Identifier::new("dept_id".to_string()),
+        ]);
+        if let JoinCondition::Using(cols) = &cond {
+            assert_eq!(cols.len(), 2);
+            assert_eq!(cols[0].value(), "id");
+            assert_eq!(cols[1].value(), "dept_id");
+        } else {
+            panic!("expected Using");
+        }
+    }
+
+    #[test]
+    fn join_condition_using_empty() {
+        // Edge case: empty USING list
+        let cond = JoinCondition::Using(vec![]);
+        if let JoinCondition::Using(cols) = &cond {
+            assert!(cols.is_empty());
+        } else {
+            panic!("expected Using");
+        }
+    }
+
+    #[test]
+    fn join_condition_natural() {
+        let cond = JoinCondition::Natural;
+        assert!(matches!(cond, JoinCondition::Natural));
+    }
+
+    // ===== TableFactor tests =====
+
+    #[test]
+    fn table_factor_table_simple() {
+        let tf = TableFactor::Table {
+            name: QualifiedName::new(None, "users".to_string()),
+            alias: None,
+        };
+        if let TableFactor::Table { name, alias } = &tf {
+            assert_eq!(name.name(), "users");
+            assert!(alias.is_none());
+        } else {
+            panic!("expected Table");
+        }
+    }
+
+    #[test]
+    fn table_factor_table_with_alias() {
+        let tf = TableFactor::Table {
+            name: QualifiedName::new(None, "users".to_string()),
+            alias: Some(TableAlias::new("u".to_string(), vec![])),
+        };
+        if let TableFactor::Table { alias, .. } = &tf {
+            let a = alias.as_ref().expect("alias should exist");
+            assert_eq!(a.name(), "u");
+        } else {
+            panic!("expected Table");
+        }
+    }
+
+    #[test]
+    fn table_factor_table_qualified() {
+        let tf = TableFactor::Table {
+            name: QualifiedName::new(Some("dbo".to_string()), "users".to_string()),
+            alias: Some(TableAlias::new("u".to_string(), vec![])),
+        };
+        if let TableFactor::Table { name, .. } = &tf {
+            assert_eq!(name.schema(), Some("dbo"));
+            assert_eq!(name.name(), "users");
+        } else {
+            panic!("expected Table");
+        }
+    }
+
+    #[test]
+    fn table_factor_derived() {
+        let sub = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        let tf = TableFactor::Derived {
+            subquery: Box::new(sub),
+            alias: Some(TableAlias::new("sub".to_string(), vec![])),
+        };
+        if let TableFactor::Derived { alias, .. } = &tf {
+            let a = alias.as_ref().expect("alias should exist");
+            assert_eq!(a.name(), "sub");
+        } else {
+            panic!("expected Derived");
+        }
+    }
+
+    #[test]
+    fn table_factor_derived_without_alias() {
+        // Edge case: derived table without alias (some dialects allow this)
+        let sub = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        let tf = TableFactor::Derived {
+            subquery: Box::new(sub),
+            alias: None,
+        };
+        if let TableFactor::Derived { alias, .. } = &tf {
+            assert!(alias.is_none());
+        } else {
+            panic!("expected Derived");
+        }
+    }
+
+    #[test]
+    fn table_factor_join() {
+        let inner_join = Join {
+            span: Span::new(0, 30),
+            join_type: JoinType::Inner,
+            table: TableFactor::Table {
+                name: QualifiedName::new(None, "t2".to_string()),
+                alias: None,
+            },
+            condition: JoinCondition::On(Expression::Comparison {
+                left: Box::new(Expression::Identifier(Identifier::new("t1.id".to_string()))),
+                op: crate::ast::ComparisonOperator::Eq,
+                right: Box::new(Expression::Identifier(Identifier::new("t2.id".to_string()))),
+            }),
+            lateral: false,
+        };
+        let tf = TableFactor::Join(Box::new(inner_join));
+        assert!(matches!(tf, TableFactor::Join(_)));
+    }
+
+    // ===== Join struct tests =====
+
+    #[test]
+    fn join_inner_basic() {
+        let join = Join {
+            span: Span::new(10, 50),
+            join_type: JoinType::Inner,
+            table: TableFactor::Table {
+                name: QualifiedName::new(None, "orders".to_string()),
+                alias: Some(TableAlias::new("o".to_string(), vec![])),
+            },
+            condition: JoinCondition::On(Expression::Comparison {
+                left: Box::new(Expression::Identifier(Identifier::new("u.id".to_string()))),
+                op: crate::ast::ComparisonOperator::Eq,
+                right: Box::new(Expression::Identifier(Identifier::new(
+                    "o.user_id".to_string(),
+                ))),
+            }),
+            lateral: false,
+        };
+        assert_eq!(join.join_type, JoinType::Inner);
+        assert!(!join.lateral);
+        assert_eq!(join.span.start, 10);
+        assert_eq!(join.span.end, 50);
+    }
+
+    #[test]
+    fn join_left() {
+        let join = Join {
+            span: Span::default(),
+            join_type: JoinType::Left,
+            table: TableFactor::Table {
+                name: QualifiedName::new(None, "profiles".to_string()),
+                alias: None,
+            },
+            condition: JoinCondition::Natural,
+            lateral: false,
+        };
+        assert_eq!(join.join_type, JoinType::Left);
+        assert!(matches!(join.condition, JoinCondition::Natural));
+    }
+
+    #[test]
+    fn join_cross() {
+        let join = Join {
+            span: Span::default(),
+            join_type: JoinType::Cross,
+            table: TableFactor::Table {
+                name: QualifiedName::new(None, "categories".to_string()),
+                alias: None,
+            },
+            condition: JoinCondition::Natural,
+            lateral: false,
+        };
+        assert_eq!(join.join_type, JoinType::Cross);
+    }
+
+    #[test]
+    fn join_right_with_using() {
+        let join = Join {
+            span: Span::default(),
+            join_type: JoinType::Right,
+            table: TableFactor::Table {
+                name: QualifiedName::new(None, "departments".to_string()),
+                alias: Some(TableAlias::new("d".to_string(), vec![])),
+            },
+            condition: JoinCondition::Using(vec![Identifier::new("dept_id".to_string())]),
+            lateral: false,
+        };
+        assert_eq!(join.join_type, JoinType::Right);
+        if let JoinCondition::Using(cols) = &join.condition {
+            assert_eq!(cols.len(), 1);
+        } else {
+            panic!("expected Using");
+        }
+    }
+
+    #[test]
+    fn join_full_outer() {
+        let join = Join {
+            span: Span::new(0, 0),
+            join_type: JoinType::Full,
+            table: TableFactor::Table {
+                name: QualifiedName::new(None, "countries".to_string()),
+                alias: None,
+            },
+            condition: JoinCondition::On(Expression::Comparison {
+                left: Box::new(Expression::Identifier(Identifier::new("c.id".to_string()))),
+                op: crate::ast::ComparisonOperator::Eq,
+                right: Box::new(Expression::Identifier(Identifier::new(
+                    "r.country_id".to_string(),
+                ))),
+            }),
+            lateral: false,
+        };
+        assert_eq!(join.join_type, JoinType::Full);
+    }
+
+    #[test]
+    fn join_lateral() {
+        // LATERAL JOIN: SELECT * FROM t1 JOIN LATERAL (SELECT ...) AS sub ON ...
+        let sub = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        let join = Join {
+            span: Span::new(20, 80),
+            join_type: JoinType::Inner,
+            table: TableFactor::Derived {
+                subquery: Box::new(sub),
+                alias: Some(TableAlias::new("sub".to_string(), vec![])),
+            },
+            condition: JoinCondition::On(Expression::Literal(crate::ast::Literal::Boolean(true))),
+            lateral: true,
+        };
+        assert!(join.lateral);
+        assert!(matches!(join.table, TableFactor::Derived { .. }));
+    }
+
+    // ===== Chained JOIN (t1 JOIN t2 ON ... JOIN t3 ON ...) =====
+
+    #[test]
+    fn chained_join() {
+        // t1 JOIN t2 ON t1.id = t2.id  ->  then JOIN t3 ON t2.id = t3.id
+        let join_t2 = Join {
+            span: Span::new(10, 40),
+            join_type: JoinType::Inner,
+            table: TableFactor::Table {
+                name: QualifiedName::new(None, "t2".to_string()),
+                alias: None,
+            },
+            condition: JoinCondition::On(Expression::Comparison {
+                left: Box::new(Expression::Identifier(Identifier::new("t1.id".to_string()))),
+                op: crate::ast::ComparisonOperator::Eq,
+                right: Box::new(Expression::Identifier(Identifier::new("t2.id".to_string()))),
+            }),
+            lateral: false,
+        };
+        let join_t3 = Join {
+            span: Span::new(41, 80),
+            join_type: JoinType::Left,
+            table: TableFactor::Join(Box::new(join_t2)),
+            condition: JoinCondition::On(Expression::Comparison {
+                left: Box::new(Expression::Identifier(Identifier::new("t2.id".to_string()))),
+                op: crate::ast::ComparisonOperator::Eq,
+                right: Box::new(Expression::Identifier(Identifier::new("t3.id".to_string()))),
+            }),
+            lateral: false,
+        };
+        // Verify the outer join is LEFT and contains an inner JOIN
+        assert_eq!(join_t3.join_type, JoinType::Left);
+        if let TableFactor::Join(inner) = &join_t3.table {
+            assert_eq!(inner.join_type, JoinType::Inner);
+        } else {
+            panic!("expected nested Join");
+        }
+    }
+
+    // ===== DialectHint tests =====
+
+    #[test]
+    fn dialect_hint_basic() {
+        let hint = DialectHint {
+            key: "index".to_string(),
+            value: "idx_users_name".to_string(),
+        };
+        assert_eq!(hint.key, "index");
+        assert_eq!(hint.value, "idx_users_name");
+    }
+
+    #[test]
+    fn dialect_hint_equality() {
+        let a = DialectHint {
+            key: "hint".to_string(),
+            value: "val".to_string(),
+        };
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn dialect_hint_inequality() {
+        let a = DialectHint {
+            key: "hint".to_string(),
+            value: "val1".to_string(),
+        };
+        let b = DialectHint {
+            key: "hint".to_string(),
+            value: "val2".to_string(),
+        };
+        assert_ne!(a, b);
+    }
+
+    // ===== Clone / Debug round-trip =====
+
+    #[test]
+    fn join_clone_equality() {
+        let join = Join {
+            span: Span::new(0, 10),
+            join_type: JoinType::Inner,
+            table: TableFactor::Table {
+                name: QualifiedName::new(None, "t".to_string()),
+                alias: None,
+            },
+            condition: JoinCondition::Natural,
+            lateral: false,
+        };
+        let cloned = join.clone();
+        assert_eq!(join, cloned);
+    }
+
+    #[test]
+    fn table_factor_clone_equality() {
+        let tf = TableFactor::Table {
+            name: QualifiedName::new(Some("schema".to_string()), "tbl".to_string()),
+            alias: Some(TableAlias::new("a".to_string(), vec!["c1".to_string()])),
+        };
+        let cloned = tf.clone();
+        assert_eq!(tf, cloned);
+    }
+
+    #[test]
+    fn join_condition_clone_equality() {
+        let cond = JoinCondition::Using(vec![Identifier::new("id".to_string())]);
+        let cloned = cond.clone();
+        assert_eq!(cond, cloned);
+    }
+
+    // ===== Edge case: join without alias =====
+
+    #[test]
+    fn join_without_alias() {
+        let join = Join {
+            span: Span::default(),
+            join_type: JoinType::Inner,
+            table: TableFactor::Table {
+                name: QualifiedName::new(None, "raw_table".to_string()),
+                alias: None,
+            },
+            condition: JoinCondition::On(Expression::Literal(crate::ast::Literal::Boolean(true))),
+            lateral: false,
+        };
+        if let TableFactor::Table { alias, .. } = &join.table {
+            assert!(alias.is_none());
+        } else {
+            panic!("expected Table");
+        }
+    }
+}

--- a/crates/common-sql/src/ast/literal.rs
+++ b/crates/common-sql/src/ast/literal.rs
@@ -1,0 +1,316 @@
+//! SQL literal values.
+//!
+//! Represents literal values that appear in SQL expressions:
+//! integers, floats, strings, booleans, and NULL.
+
+// TDD: Tests written FIRST, implementation follows.
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // ---- Construction tests ----
+
+    #[test]
+    fn test_integer_literal() {
+        let lit = Literal::Integer(42_i64);
+        assert!(matches!(lit, Literal::Integer(n) if n == 42));
+    }
+
+    #[test]
+    fn test_integer_literal_negative() {
+        let lit = Literal::Integer(-1_i64);
+        assert!(matches!(lit, Literal::Integer(n) if n == -1));
+    }
+
+    #[test]
+    fn test_integer_literal_max() {
+        let lit = Literal::Integer(i64::MAX);
+        assert!(matches!(lit, Literal::Integer(n) if n == i64::MAX));
+    }
+
+    #[test]
+    fn test_integer_literal_min() {
+        let lit = Literal::Integer(i64::MIN);
+        assert!(matches!(lit, Literal::Integer(n) if n == i64::MIN));
+    }
+
+    #[test]
+    fn test_float_literal() {
+        let lit = Literal::Float("3.14".to_string());
+        assert!(matches!(lit, Literal::Float(s) if s == "3.14"));
+    }
+
+    #[test]
+    fn test_float_literal_preserves_precision() {
+        // DECIMAL(18,4) value must not lose precision
+        let lit = Literal::Float("123456789012.3456".to_string());
+        assert!(matches!(lit, Literal::Float(s) if s == "123456789012.3456"));
+    }
+
+    #[test]
+    fn test_float_literal_scientific_notation() {
+        let lit = Literal::Float("1.5e-10".to_string());
+        assert!(matches!(lit, Literal::Float(s) if s == "1.5e-10"));
+    }
+
+    #[test]
+    fn test_float_literal_zero() {
+        let lit = Literal::Float("0.0".to_string());
+        assert!(matches!(lit, Literal::Float(s) if s == "0.0"));
+    }
+
+    #[test]
+    fn test_string_literal() {
+        let lit = Literal::String("hello world".to_string());
+        assert!(matches!(lit, Literal::String(s) if s == "hello world"));
+    }
+
+    #[test]
+    fn test_string_literal_empty() {
+        let lit = Literal::String(String::new());
+        assert!(matches!(lit, Literal::String(s) if s.is_empty()));
+    }
+
+    #[test]
+    fn test_string_literal_with_special_chars() {
+        let lit = Literal::String("O'Brien".to_string());
+        assert!(matches!(lit, Literal::String(s) if s == "O'Brien"));
+    }
+
+    #[test]
+    fn test_string_literal_unicode() {
+        let lit = Literal::String("日本語テスト".to_string());
+        assert!(matches!(lit, Literal::String(s) if s == "日本語テスト"));
+    }
+
+    #[test]
+    fn test_boolean_literal_true() {
+        let lit = Literal::Boolean(true);
+        assert!(matches!(lit, Literal::Boolean(b) if b));
+    }
+
+    #[test]
+    fn test_boolean_literal_false() {
+        let lit = Literal::Boolean(false);
+        assert!(matches!(lit, Literal::Boolean(b) if !b));
+    }
+
+    #[test]
+    fn test_null_literal() {
+        let lit = Literal::Null;
+        assert!(matches!(lit, Literal::Null));
+    }
+
+    // ---- Debug derive tests ----
+
+    #[test]
+    fn test_debug_integer() {
+        let lit = Literal::Integer(42);
+        let debug_str = format!("{lit:?}");
+        assert!(debug_str.contains("42"));
+    }
+
+    #[test]
+    fn test_debug_float() {
+        let lit = Literal::Float("3.14".to_string());
+        let debug_str = format!("{lit:?}");
+        assert!(debug_str.contains("3.14"));
+    }
+
+    #[test]
+    fn test_debug_string() {
+        let lit = Literal::String("test".to_string());
+        let debug_str = format!("{lit:?}");
+        assert!(debug_str.contains("test"));
+    }
+
+    #[test]
+    fn test_debug_boolean() {
+        let lit = Literal::Boolean(true);
+        let debug_str = format!("{lit:?}");
+        assert!(debug_str.contains("true"));
+    }
+
+    #[test]
+    fn test_debug_null() {
+        let lit = Literal::Null;
+        let debug_str = format!("{lit:?}");
+        assert!(debug_str.contains("Null"));
+    }
+
+    // ---- Clone derive tests ----
+
+    #[test]
+    fn test_clone_integer() {
+        let lit = Literal::Integer(42);
+        let cloned = lit.clone();
+        assert_eq!(lit, cloned);
+    }
+
+    #[test]
+    fn test_clone_float() {
+        let lit = Literal::Float("3.14".to_string());
+        let cloned = lit.clone();
+        assert_eq!(lit, cloned);
+    }
+
+    #[test]
+    fn test_clone_string() {
+        let lit = Literal::String("hello".to_string());
+        let cloned = lit.clone();
+        assert_eq!(lit, cloned);
+    }
+
+    #[test]
+    fn test_clone_boolean() {
+        let lit = Literal::Boolean(true);
+        let cloned = lit.clone();
+        assert_eq!(lit, cloned);
+    }
+
+    #[test]
+    fn test_clone_null() {
+        let lit = Literal::Null;
+        let cloned = lit.clone();
+        assert_eq!(lit, cloned);
+    }
+
+    // ---- PartialEq derive tests ----
+
+    #[test]
+    fn test_eq_same_integer() {
+        assert_eq!(Literal::Integer(42), Literal::Integer(42));
+    }
+
+    #[test]
+    fn test_eq_different_integer() {
+        assert_ne!(Literal::Integer(42), Literal::Integer(43));
+    }
+
+    #[test]
+    fn test_eq_same_float() {
+        assert_eq!(
+            Literal::Float("3.14".to_string()),
+            Literal::Float("3.14".to_string())
+        );
+    }
+
+    #[test]
+    fn test_eq_different_float() {
+        assert_ne!(
+            Literal::Float("3.14".to_string()),
+            Literal::Float("3.14159".to_string())
+        );
+    }
+
+    #[test]
+    fn test_eq_same_string() {
+        assert_eq!(
+            Literal::String("hello".to_string()),
+            Literal::String("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn test_eq_different_string() {
+        assert_ne!(
+            Literal::String("hello".to_string()),
+            Literal::String("world".to_string())
+        );
+    }
+
+    #[test]
+    fn test_eq_same_boolean() {
+        assert_eq!(Literal::Boolean(true), Literal::Boolean(true));
+        assert_eq!(Literal::Boolean(false), Literal::Boolean(false));
+    }
+
+    #[test]
+    fn test_eq_different_boolean() {
+        assert_ne!(Literal::Boolean(true), Literal::Boolean(false));
+    }
+
+    #[test]
+    fn test_eq_null() {
+        assert_eq!(Literal::Null, Literal::Null);
+    }
+
+    #[test]
+    fn test_ne_cross_types() {
+        // Different variants are never equal
+        assert_ne!(Literal::Integer(1), Literal::Float("1".to_string()));
+        assert_ne!(Literal::Integer(0), Literal::Boolean(false));
+        assert_ne!(Literal::Integer(0), Literal::Null);
+        assert_ne!(Literal::String("true".to_string()), Literal::Boolean(true));
+        assert_ne!(Literal::Float("0".to_string()), Literal::Null);
+    }
+
+    // ---- Eq derive tests (Hash / HashMap usage) ----
+
+    #[test]
+    fn test_eq_hash_consistency() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(Literal::Integer(42));
+        set.insert(Literal::Integer(42)); // duplicate
+        set.insert(Literal::Integer(43));
+        set.insert(Literal::Null);
+        assert_eq!(set.len(), 3);
+    }
+
+    // ---- Edge case tests ----
+
+    #[test]
+    fn test_integer_zero() {
+        let lit = Literal::Integer(0);
+        assert!(matches!(lit, Literal::Integer(0)));
+    }
+
+    #[test]
+    fn test_float_empty_string_is_valid() {
+        // Edge: empty string for float — semantically unusual but type-valid
+        let lit = Literal::Float(String::new());
+        assert!(matches!(lit, Literal::Float(s) if s.is_empty()));
+    }
+
+    #[test]
+    fn test_string_literal_with_newlines() {
+        let lit = Literal::String("line1\nline2".to_string());
+        assert!(matches!(lit, Literal::String(s) if s.contains('\n')));
+    }
+}
+
+/// SQL literal value.
+///
+/// Uses `Float(String)` instead of `Float(f64)` to preserve decimal precision
+/// across dialect transpilation (e.g., `DECIMAL(18,4)` values must not lose
+/// precision when converting from ASE T-SQL to MySQL).
+///
+/// # Examples
+///
+/// ```
+/// use common_sql::ast::Literal;
+///
+/// let int_lit = Literal::Integer(42);
+/// let float_lit = Literal::Float("3.14159".to_string());
+/// let str_lit = Literal::String("hello".to_string());
+/// let bool_lit = Literal::Boolean(true);
+/// let null_lit = Literal::Null;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Literal {
+    /// Integer literal (e.g., `42`, `-1`, `0`)
+    Integer(i64),
+    /// Float literal stored as string to preserve precision (e.g., `"3.14"`, `"1.5e-10"`)
+    Float(String),
+    /// String literal (e.g., `'hello'`, `'O''Brien'`)
+    String(String),
+    /// Boolean literal (`TRUE` / `FALSE`)
+    Boolean(bool),
+    /// NULL literal
+    Null,
+}

--- a/crates/common-sql/src/ast/mod.rs
+++ b/crates/common-sql/src/ast/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod clause;
 pub mod datatype;
+pub mod ddl;
 pub mod expression;
 pub mod identifier;
 pub mod join;
@@ -14,6 +15,11 @@ pub use clause::{
     SortDirection, WithClause,
 };
 pub use datatype::DataType;
+pub use ddl::{
+    AlterTableAction, AlterTableStatement, ColumnConstraint, ColumnDef, CreateIndexStatement,
+    CreateTableStatement, DropIndexStatement, DropTableStatement, IndexColumn, TableConstraint,
+    TableOptions,
+};
 pub use expression::{
     BinaryOperator, ComparisonOperator, Expression, InList, LogicalOperator, UnaryOperator,
 };
@@ -21,4 +27,7 @@ pub use identifier::{Identifier, QualifiedName, TableAlias};
 pub use join::{DialectHint, Join, JoinCondition, JoinType, TableFactor};
 pub use literal::Literal;
 pub use span::{Position, Span};
-pub use statement::{SelectItem, SelectStatement, Statement};
+pub use statement::{
+    Assignment, ConflictAction, DeleteStatement, InsertSource, InsertStatement, OnConflict,
+    SelectItem, SelectStatement, Statement, UpdateStatement,
+};

--- a/crates/common-sql/src/ast/mod.rs
+++ b/crates/common-sql/src/ast/mod.rs
@@ -1,5 +1,6 @@
 //! AST module — dialect-independent SQL nodes.
 
+pub mod clause;
 pub mod datatype;
 pub mod expression;
 pub mod identifier;
@@ -8,6 +9,10 @@ pub mod literal;
 pub mod span;
 pub mod statement;
 
+pub use clause::{
+    Cte, GroupByClause, GroupByItem, LimitClause, NullOrdering, OrderByClause, OrderByItem,
+    SortDirection, WithClause,
+};
 pub use datatype::DataType;
 pub use expression::{
     BinaryOperator, ComparisonOperator, Expression, InList, LogicalOperator, UnaryOperator,

--- a/crates/common-sql/src/ast/mod.rs
+++ b/crates/common-sql/src/ast/mod.rs
@@ -1,0 +1,19 @@
+//! AST module — dialect-independent SQL nodes.
+
+pub mod datatype;
+pub mod expression;
+pub mod identifier;
+pub mod join;
+pub mod literal;
+pub mod span;
+pub mod statement;
+
+pub use datatype::DataType;
+pub use expression::{
+    BinaryOperator, ComparisonOperator, Expression, InList, LogicalOperator, UnaryOperator,
+};
+pub use identifier::{Identifier, QualifiedName, TableAlias};
+pub use join::{DialectHint, Join, JoinCondition, JoinType, TableFactor};
+pub use literal::Literal;
+pub use span::{Position, Span};
+pub use statement::{SelectItem, SelectStatement, Statement};

--- a/crates/common-sql/src/ast/span.rs
+++ b/crates/common-sql/src/ast/span.rs
@@ -1,0 +1,63 @@
+//! Span and Position types for source location tracking.
+//!
+//! These types mirror `tsql_token::Span` and `tsql_token::Position` layout
+//! for zero-cost conversion in the tsql-parser conversion layer.
+
+/// Source location span (byte offsets).
+///
+/// Same layout as `tsql_token::Span { start: u32, end: u32 }` —
+/// conversion via `From<tsql_token::Span>` will be implemented in tsql-parser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Span {
+    /// Start byte offset (inclusive).
+    pub start: u32,
+    /// End byte offset (exclusive).
+    pub end: u32,
+}
+
+impl Span {
+    /// Creates a new span from start and end byte offsets.
+    #[must_use]
+    pub fn new(start: u32, end: u32) -> Self {
+        Self { start, end }
+    }
+
+    /// Returns `true` if this span covers zero bytes.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+}
+
+/// Human-readable source position (line, column, offset).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Position {
+    /// Line number (1-indexed).
+    pub line: u32,
+    /// Column number (1-indexed).
+    pub column: u32,
+    /// Byte offset from start of source.
+    pub offset: u32,
+}
+
+impl Position {
+    /// Creates a new position.
+    #[must_use]
+    pub fn new(line: u32, column: u32, offset: u32) -> Self {
+        Self {
+            line,
+            column,
+            offset,
+        }
+    }
+}
+
+impl Default for Position {
+    fn default() -> Self {
+        Self {
+            line: 1,
+            column: 1,
+            offset: 0,
+        }
+    }
+}

--- a/crates/common-sql/src/ast/statement.rs
+++ b/crates/common-sql/src/ast/statement.rs
@@ -1,0 +1,346 @@
+//! SQL statement nodes.
+
+use crate::ast::clause::{GroupByClause, LimitClause, OrderByClause, WithClause};
+use crate::ast::identifier::Identifier;
+use crate::ast::join::TableFactor;
+use crate::ast::span::Span;
+use crate::ast::Expression;
+
+/// Top-level SQL statement.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Statement {
+    /// SELECT statement.
+    Select(SelectStatement),
+}
+
+/// SELECT statement.
+///
+/// Full query representation covering projection, FROM (with JOIN support via
+/// [`TableFactor`]), WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, and an optional
+/// WITH (CTE) clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectStatement {
+    /// Source span of the entire statement.
+    pub span: Span,
+    /// `WITH` clause (one or more CTEs), if present.
+    pub with: Option<WithClause>,
+    /// Projection list (`SELECT` list).
+    pub projection: Vec<SelectItem>,
+    /// FROM clause (`None` for a `SELECT` with no FROM).
+    pub from: Option<TableFactor>,
+    /// WHERE clause.
+    pub where_clause: Option<Expression>,
+    /// GROUP BY clause.
+    pub group_by: Option<GroupByClause>,
+    /// HAVING clause.
+    pub having: Option<Expression>,
+    /// ORDER BY clause.
+    pub order_by: Option<OrderByClause>,
+    /// LIMIT / OFFSET clause.
+    pub limit: Option<LimitClause>,
+}
+
+/// SELECT list item.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SelectItem {
+    /// An expression with optional alias.
+    Expression {
+        /// The projected expression.
+        expr: Expression,
+        /// Optional column alias (`AS name`).
+        alias: Option<Identifier>,
+    },
+    /// `table.*` — all columns from a specific table.
+    QualifiedWildcard {
+        /// Table name.
+        table: Identifier,
+    },
+    /// `*` — all columns.
+    Wildcard,
+}
+
+// ---------------------------------------------------------------------------
+// Minimal constructors for testing
+// ---------------------------------------------------------------------------
+
+impl SelectStatement {
+    /// Create a minimal SELECT statement with just projection.
+    ///
+    /// All optional clauses (`with`, `from`, `where_clause`, `group_by`,
+    /// `having`, `order_by`, `limit`) are initialized to `None`.
+    #[must_use]
+    pub fn simple(projection: Vec<SelectItem>) -> Self {
+        Self {
+            span: Span::new(0, 0),
+            with: None,
+            projection,
+            from: None,
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::ast::clause::{Cte, NullOrdering, SortDirection};
+    use crate::ast::clause::{
+        GroupByClause, GroupByItem, LimitClause, OrderByClause, OrderByItem, WithClause,
+    };
+    use crate::ast::identifier::{QualifiedName, TableAlias};
+    use crate::ast::join::{Join, JoinCondition, JoinType, TableFactor};
+    use crate::ast::literal::Literal;
+
+    // -- helpers -------------------------------------------------------------
+
+    fn ident_expr(name: &str) -> Expression {
+        Expression::Identifier(Identifier::new(name.to_string()))
+    }
+
+    fn int_expr(n: i64) -> Expression {
+        Expression::Literal(Literal::Integer(n))
+    }
+
+    fn table_factor(name: &str) -> TableFactor {
+        TableFactor::Table {
+            name: QualifiedName::new(None, name.to_string()),
+            alias: None,
+        }
+    }
+
+    // -- simple() constructor: every optional clause defaults to None --------
+
+    #[test]
+    fn simple_initializes_all_new_fields_to_none() {
+        let stmt = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        assert!(stmt.with.is_none());
+        assert!(stmt.from.is_none());
+        assert!(stmt.where_clause.is_none());
+        assert!(stmt.group_by.is_none());
+        assert!(stmt.having.is_none());
+        assert!(stmt.order_by.is_none());
+        assert!(stmt.limit.is_none());
+        assert_eq!(stmt.span, Span::new(0, 0));
+    }
+
+    #[test]
+    fn simple_preserves_projection() {
+        let proj = vec![
+            SelectItem::Expression {
+                expr: ident_expr("id"),
+                alias: None,
+            },
+            SelectItem::Wildcard,
+        ];
+        let stmt = SelectStatement::simple(proj.clone());
+        assert_eq!(stmt.projection.len(), 2);
+        assert!(matches!(stmt.projection[1], SelectItem::Wildcard));
+    }
+
+    // -- struct-literal construction with every clause populated -------------
+
+    #[test]
+    fn full_select_statement_with_all_clauses() {
+        let stmt = SelectStatement {
+            span: Span::new(0, 100),
+            with: Some(WithClause {
+                recursive: false,
+                ctes: vec![Cte {
+                    name: "src".to_string(),
+                    columns: vec![],
+                    query: Box::new(SelectStatement::simple(vec![SelectItem::Wildcard])),
+                    materialized: None,
+                }],
+            }),
+            projection: vec![SelectItem::Wildcard],
+            from: Some(table_factor("users")),
+            where_clause: Some(ident_expr("active")),
+            group_by: Some(GroupByClause {
+                span: Span::new(20, 40),
+                items: vec![GroupByItem::Expression(ident_expr("dept"))],
+            }),
+            having: Some(ident_expr("count")),
+            order_by: Some(OrderByClause {
+                span: Span::new(50, 70),
+                items: vec![OrderByItem {
+                    expr: ident_expr("name"),
+                    direction: Some(SortDirection::Asc),
+                    nulls: None,
+                }],
+            }),
+            limit: Some(LimitClause {
+                span: Span::new(80, 90),
+                limit: int_expr(10),
+                offset: None,
+            }),
+        };
+        assert!(stmt.with.is_some());
+        assert!(stmt.from.is_some());
+        assert!(stmt.group_by.is_some());
+        assert!(stmt.having.is_some());
+        assert!(stmt.order_by.is_some());
+        assert!(stmt.limit.is_some());
+    }
+
+    // -- individual clause assignment ---------------------------------------
+
+    #[test]
+    fn select_with_with_clause_recursive() {
+        let mut stmt = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        stmt.with = Some(WithClause {
+            recursive: true,
+            ctes: vec![],
+        });
+        let wc = stmt.with.as_ref().expect("with should be set");
+        assert!(wc.recursive);
+        assert!(wc.ctes.is_empty());
+    }
+
+    #[test]
+    fn select_from_table_factor() {
+        let mut stmt = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        stmt.from = Some(TableFactor::Table {
+            name: QualifiedName::new(Some("dbo".to_string()), "orders".to_string()),
+            alias: Some(TableAlias::new("o".to_string(), vec![])),
+        });
+        if let Some(TableFactor::Table { name, alias }) = &stmt.from {
+            assert_eq!(name.schema(), Some("dbo"));
+            assert_eq!(name.name(), "orders");
+            assert_eq!(alias.as_ref().expect("alias").name(), "o");
+        } else {
+            panic!("expected Table factor");
+        }
+    }
+
+    #[test]
+    fn select_group_by_and_having() {
+        let mut stmt = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        stmt.group_by = Some(GroupByClause {
+            span: Span::new(0, 10),
+            items: vec![
+                GroupByItem::Expression(ident_expr("a")),
+                GroupByItem::Rollup(vec![ident_expr("b")]),
+            ],
+        });
+        stmt.having = Some(ident_expr("total"));
+        assert_eq!(stmt.group_by.as_ref().expect("group_by").items.len(), 2);
+        assert!(stmt.having.is_some());
+    }
+
+    #[test]
+    fn select_order_by_with_nulls_ordering() {
+        let mut stmt = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        stmt.order_by = Some(OrderByClause {
+            span: Span::new(0, 20),
+            items: vec![OrderByItem {
+                expr: ident_expr("salary"),
+                direction: Some(SortDirection::Desc),
+                nulls: Some(NullOrdering::NullsFirst),
+            }],
+        });
+        let ob = stmt.order_by.as_ref().expect("order_by");
+        assert_eq!(ob.items[0].nulls, Some(NullOrdering::NullsFirst));
+    }
+
+    #[test]
+    fn select_limit_with_offset() {
+        let mut stmt = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        stmt.limit = Some(LimitClause {
+            span: Span::new(0, 5),
+            limit: int_expr(25),
+            offset: Some(int_expr(5)),
+        });
+        let lim = stmt.limit.as_ref().expect("limit");
+        assert_eq!(lim.offset, Some(int_expr(5)));
+    }
+
+    // -- Statement enum still wraps SelectStatement --------------------------
+
+    #[test]
+    fn statement_select_wraps_select_statement() {
+        let inner = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        // Verify the wrapped statement carries the default empty shape before
+        // wrapping (Statement currently has a single variant, so we inspect
+        // the inner value directly rather than pattern-matching the enum).
+        assert!(inner.from.is_none());
+        assert!(inner.with.is_none());
+        let stmt = Statement::Select(inner);
+        // Document the wrapping relationship; this becomes a real discriminant
+        // check once Task 4.3 adds Insert/Update/Delete variants.
+        assert!(matches!(stmt, Statement::Select(_)));
+        // Clone + PartialEq preserved through the new fields.
+        assert_eq!(stmt.clone(), stmt);
+    }
+
+    // -- Recursive nesting (SelectStatement <-> TableFactor) -----------------
+    // SELECT * FROM (SELECT * FROM t1 JOIN t2 ON ...) AS sub
+    #[test]
+    fn recursive_nesting_derived_subquery_containing_join() {
+        let inner_join = Join {
+            span: Span::new(0, 30),
+            join_type: JoinType::Inner,
+            table: table_factor("t2"),
+            condition: JoinCondition::On(ident_expr("t1.id")),
+            lateral: false,
+        };
+        // inner SELECT: projection references the joined table factor
+        let inner_select = SelectStatement {
+            span: Span::new(0, 50),
+            with: None,
+            projection: vec![SelectItem::Wildcard],
+            from: Some(TableFactor::Join(Box::new(inner_join))),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+        };
+        // outer SELECT: FROM is a Derived subquery wrapping the inner select
+        let outer = SelectStatement {
+            span: Span::new(0, 100),
+            with: None,
+            projection: vec![SelectItem::Wildcard],
+            from: Some(TableFactor::Derived {
+                subquery: Box::new(inner_select),
+                alias: Some(TableAlias::new("sub".to_string(), vec![])),
+            }),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+        };
+        // Verify the full recursion depth round-trips through Clone + PartialEq.
+        let cloned = outer.clone();
+        assert_eq!(outer, cloned);
+        if let Some(TableFactor::Derived { subquery, alias }) = &outer.from {
+            assert_eq!(alias.as_ref().expect("alias").name(), "sub");
+            assert!(matches!(
+                subquery.from.as_ref().expect("inner from"),
+                TableFactor::Join(_)
+            ));
+        } else {
+            panic!("expected Derived factor");
+        }
+    }
+
+    // -- Edge case: bare select with no projection ---------------------------
+
+    #[test]
+    fn empty_projection_select() {
+        let stmt = SelectStatement::simple(vec![]);
+        assert!(stmt.projection.is_empty());
+        assert!(stmt.from.is_none());
+    }
+}

--- a/crates/common-sql/src/ast/statement.rs
+++ b/crates/common-sql/src/ast/statement.rs
@@ -1,16 +1,39 @@
 //! SQL statement nodes.
 
 use crate::ast::clause::{GroupByClause, LimitClause, OrderByClause, WithClause};
-use crate::ast::identifier::Identifier;
+use crate::ast::ddl::{
+    AlterTableStatement, CreateIndexStatement, CreateTableStatement, DropIndexStatement,
+    DropTableStatement,
+};
+use crate::ast::identifier::{Identifier, QualifiedName};
 use crate::ast::join::TableFactor;
 use crate::ast::span::Span;
 use crate::ast::Expression;
 
 /// Top-level SQL statement.
+///
+/// Variants are boxed to keep the enum small regardless of which statement
+/// type dominates (avoids `clippy::large_enum_variant`).
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
     /// SELECT statement.
-    Select(SelectStatement),
+    Select(Box<SelectStatement>),
+    /// INSERT statement.
+    Insert(Box<InsertStatement>),
+    /// UPDATE statement.
+    Update(Box<UpdateStatement>),
+    /// DELETE statement.
+    Delete(Box<DeleteStatement>),
+    /// `CREATE TABLE` statement.
+    CreateTable(Box<CreateTableStatement>),
+    /// `ALTER TABLE` statement.
+    AlterTable(Box<AlterTableStatement>),
+    /// `DROP TABLE` statement.
+    DropTable(Box<DropTableStatement>),
+    /// `CREATE INDEX` statement.
+    CreateIndex(Box<CreateIndexStatement>),
+    /// `DROP INDEX` statement.
+    DropIndex(Box<DropIndexStatement>),
 }
 
 /// SELECT statement.
@@ -60,6 +83,116 @@ pub enum SelectItem {
 }
 
 // ---------------------------------------------------------------------------
+// ON CONFLICT support (Task 4.3 / Task 2)
+// ---------------------------------------------------------------------------
+
+/// A column assignment used in `UPDATE SET` and `ON CONFLICT DO UPDATE`.
+///
+/// Represents `column = value`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Assignment {
+    /// The target column.
+    pub column: Identifier,
+    /// The value to assign.
+    pub value: Expression,
+}
+
+/// The action to take when an `ON CONFLICT` clause fires.
+///
+/// Mirrors PostgreSQL's `ON CONFLICT [DO NOTHING | DO UPDATE SET ...]`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConflictAction {
+    /// `ON CONFLICT DO NOTHING` — discard the conflicting row.
+    DoNothing,
+    /// `ON CONFLICT DO UPDATE SET ...` — update the existing row.
+    ///
+    /// Carries the `SET` assignments (e.g. `name = EXCLUDED.name`).
+    DoUpdate(Vec<Assignment>),
+}
+
+/// An `ON CONFLICT` clause on an [`InsertStatement`].
+///
+/// PostgreSQL-specific; carries an optional conflict target (the columns or
+/// constraint inference target) and the [`ConflictAction`] to perform.
+/// This type unblocks `postgresql-emitter`'s `ON CONFLICT` emission.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OnConflict {
+    /// Source span of the entire `ON CONFLICT ...` clause.
+    pub span: Span,
+    /// What to do when a conflict is detected.
+    pub action: ConflictAction,
+    /// Columns (or constraint inference target) the clause applies to.
+    ///
+    /// `None` means no explicit target (catch-all conflict handler).
+    pub conflict_target: Option<Vec<Identifier>>,
+}
+
+// ---------------------------------------------------------------------------
+// DML statements: INSERT / UPDATE / DELETE (Task 4.3)
+// ---------------------------------------------------------------------------
+
+/// INSERT statement.
+///
+/// Represents `INSERT INTO table [(columns...)] { VALUES (...) | SELECT ... }`
+/// with an optional `ON CONFLICT` clause (PostgreSQL).
+#[derive(Debug, Clone, PartialEq)]
+pub struct InsertStatement {
+    /// Source span of the entire statement.
+    pub span: Span,
+    /// Target table name (`schema.table` or just `table`).
+    pub table: QualifiedName,
+    /// Explicit column list, if present.
+    pub columns: Vec<Identifier>,
+    /// The source of rows to insert (`VALUES` or `SELECT`).
+    pub source: InsertSource,
+    /// Optional `ON CONFLICT` clause (PostgreSQL).
+    pub on_conflict: Option<OnConflict>,
+}
+
+/// The row source of an [`InsertStatement`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum InsertSource {
+    /// `VALUES (row0), (row1), ...` — each inner `Vec` is one row of values.
+    Values(Vec<Vec<Expression>>),
+    /// `INSERT INTO ... SELECT ...` — the rows come from a subquery.
+    Select(Box<SelectStatement>),
+}
+
+/// UPDATE statement.
+///
+/// Represents `UPDATE table SET assignments [FROM from] [WHERE where_clause]`.
+/// The `FROM` clause is supported by T-SQL and PostgreSQL.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UpdateStatement {
+    /// Source span of the entire statement.
+    pub span: Span,
+    /// Target table reference.
+    pub table: TableFactor,
+    /// `SET` assignments (`column = value`).
+    pub assignments: Vec<Assignment>,
+    /// Optional `FROM` clause (T-SQL / PostgreSQL).
+    pub from: Option<TableFactor>,
+    /// WHERE clause.
+    pub where_clause: Option<Expression>,
+}
+
+/// DELETE statement.
+///
+/// Represents `DELETE FROM table [USING ...] [WHERE where_clause]`.
+/// The `USING` clause is a PostgreSQL extension for multi-table deletes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeleteStatement {
+    /// Source span of the entire statement.
+    pub span: Span,
+    /// Target table reference.
+    pub table: TableFactor,
+    /// Optional `USING` clause (PostgreSQL multi-table delete).
+    pub using: Option<Vec<TableFactor>>,
+    /// WHERE clause.
+    pub where_clause: Option<Expression>,
+}
+
+// ---------------------------------------------------------------------------
 // Minimal constructors for testing
 // ---------------------------------------------------------------------------
 
@@ -98,6 +231,7 @@ mod tests {
     use crate::ast::clause::{
         GroupByClause, GroupByItem, LimitClause, OrderByClause, OrderByItem, WithClause,
     };
+    use crate::ast::expression::{BinaryOperator, ComparisonOperator, InList};
     use crate::ast::identifier::{QualifiedName, TableAlias};
     use crate::ast::join::{Join, JoinCondition, JoinType, TableFactor};
     use crate::ast::literal::Literal;
@@ -270,15 +404,14 @@ mod tests {
     #[test]
     fn statement_select_wraps_select_statement() {
         let inner = SelectStatement::simple(vec![SelectItem::Wildcard]);
-        // Verify the wrapped statement carries the default empty shape before
-        // wrapping (Statement currently has a single variant, so we inspect
-        // the inner value directly rather than pattern-matching the enum).
         assert!(inner.from.is_none());
         assert!(inner.with.is_none());
-        let stmt = Statement::Select(inner);
-        // Document the wrapping relationship; this becomes a real discriminant
-        // check once Task 4.3 adds Insert/Update/Delete variants.
+        let stmt = Statement::Select(Box::new(inner));
+        // Real discriminant checks against all four Statement variants.
         assert!(matches!(stmt, Statement::Select(_)));
+        assert!(!matches!(stmt, Statement::Insert(_)));
+        assert!(!matches!(stmt, Statement::Update(_)));
+        assert!(!matches!(stmt, Statement::Delete(_)));
         // Clone + PartialEq preserved through the new fields.
         assert_eq!(stmt.clone(), stmt);
     }
@@ -342,5 +475,515 @@ mod tests {
         let stmt = SelectStatement::simple(vec![]);
         assert!(stmt.projection.is_empty());
         assert!(stmt.from.is_none());
+    }
+
+    // ===== Task 4.3 / OnConflict (Task 2): minimal ON CONFLICT type =====
+
+    #[test]
+    fn on_conflict_do_nothing_without_target() {
+        // INSERT INTO t (id) VALUES (1) ON CONFLICT DO NOTHING
+        let oc = OnConflict {
+            span: Span::new(0, 10),
+            action: ConflictAction::DoNothing,
+            conflict_target: None,
+        };
+        assert!(matches!(oc.action, ConflictAction::DoNothing));
+        assert!(oc.conflict_target.is_none());
+    }
+
+    #[test]
+    fn on_conflict_do_nothing_with_target() {
+        // ON CONFLICT (id) DO NOTHING
+        let oc = OnConflict {
+            span: Span::new(0, 10),
+            action: ConflictAction::DoNothing,
+            conflict_target: Some(vec![Identifier::new("id".to_string())]),
+        };
+        let target = oc.conflict_target.as_ref().expect("target");
+        assert_eq!(target.len(), 1);
+        assert_eq!(target[0].value(), "id");
+    }
+
+    #[test]
+    fn on_conflict_do_update_with_assignments() {
+        // ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name
+        let oc = OnConflict {
+            span: Span::new(0, 40),
+            action: ConflictAction::DoUpdate(vec![Assignment {
+                column: Identifier::new("name".to_string()),
+                value: ident_expr("excluded_name"),
+            }]),
+            conflict_target: Some(vec![Identifier::new("id".to_string())]),
+        };
+        if let ConflictAction::DoUpdate(assigns) = &oc.action {
+            assert_eq!(assigns.len(), 1);
+            assert_eq!(assigns[0].column.value(), "name");
+        } else {
+            panic!("expected DoUpdate");
+        }
+    }
+
+    #[test]
+    fn on_conflict_do_update_multiple_assignments() {
+        let oc = OnConflict {
+            span: Span::new(0, 60),
+            action: ConflictAction::DoUpdate(vec![
+                Assignment {
+                    column: Identifier::new("name".to_string()),
+                    value: ident_expr("x"),
+                },
+                Assignment {
+                    column: Identifier::new("count".to_string()),
+                    value: int_expr(1),
+                },
+            ]),
+            conflict_target: None,
+        };
+        if let ConflictAction::DoUpdate(assigns) = &oc.action {
+            assert_eq!(assigns.len(), 2);
+        } else {
+            panic!("expected DoUpdate");
+        }
+    }
+
+    #[test]
+    fn on_conflict_clone_and_equality() {
+        let oc = OnConflict {
+            span: Span::new(0, 10),
+            action: ConflictAction::DoNothing,
+            conflict_target: Some(vec![Identifier::new("id".to_string())]),
+        };
+        let cloned = oc.clone();
+        assert_eq!(oc, cloned);
+    }
+
+    #[test]
+    fn on_conflict_inequality_on_action() {
+        let a = OnConflict {
+            span: Span::new(0, 10),
+            action: ConflictAction::DoNothing,
+            conflict_target: None,
+        };
+        let b = OnConflict {
+            span: Span::new(0, 10),
+            action: ConflictAction::DoUpdate(vec![]),
+            conflict_target: None,
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn assignment_basic() {
+        let a = Assignment {
+            column: Identifier::new("status".to_string()),
+            value: int_expr(1),
+        };
+        assert_eq!(a.column.value(), "status");
+        assert!(matches!(a.value, Expression::Literal(Literal::Integer(1))));
+    }
+
+    #[test]
+    fn assignment_clone_equality() {
+        let a = Assignment {
+            column: Identifier::new("name".to_string()),
+            value: ident_expr("other"),
+        };
+        let cloned = a.clone();
+        assert_eq!(a, cloned);
+    }
+
+    // ===== Task 4.3: INSERT statement =====
+
+    fn qualified(name: &str) -> QualifiedName {
+        QualifiedName::new(None, name.to_string())
+    }
+
+    #[test]
+    fn insert_values_basic() {
+        // INSERT INTO users (id, name) VALUES (1, 'a'), (2, 'b')
+        let stmt = InsertStatement {
+            span: Span::new(0, 50),
+            table: qualified("users"),
+            columns: vec![
+                Identifier::new("id".to_string()),
+                Identifier::new("name".to_string()),
+            ],
+            source: InsertSource::Values(vec![
+                vec![int_expr(1), ident_expr("a")],
+                vec![int_expr(2), ident_expr("b")],
+            ]),
+            on_conflict: None,
+        };
+        assert_eq!(stmt.columns.len(), 2);
+        if let InsertSource::Values(rows) = &stmt.source {
+            assert_eq!(rows.len(), 2);
+            assert_eq!(rows[0].len(), 2);
+        } else {
+            panic!("expected Values source");
+        }
+        assert!(stmt.on_conflict.is_none());
+    }
+
+    #[test]
+    fn insert_with_on_conflict_do_nothing() {
+        let stmt = InsertStatement {
+            span: Span::new(0, 40),
+            table: qualified("users"),
+            columns: vec![Identifier::new("id".to_string())],
+            source: InsertSource::Values(vec![vec![int_expr(1)]]),
+            on_conflict: Some(OnConflict {
+                span: Span::new(20, 40),
+                action: ConflictAction::DoNothing,
+                conflict_target: None,
+            }),
+        };
+        let oc = stmt.on_conflict.as_ref().expect("on_conflict");
+        assert!(matches!(oc.action, ConflictAction::DoNothing));
+    }
+
+    #[test]
+    fn insert_values_empty_rows_edge_case() {
+        // Edge case: VALUES with no rows (degenerate but representable).
+        let stmt = InsertStatement {
+            span: Span::new(0, 10),
+            table: qualified("t"),
+            columns: vec![],
+            source: InsertSource::Values(vec![]),
+            on_conflict: None,
+        };
+        if let InsertSource::Values(rows) = &stmt.source {
+            assert!(rows.is_empty());
+        } else {
+            panic!("expected Values source");
+        }
+    }
+
+    #[test]
+    fn insert_clone_equality() {
+        let stmt = InsertStatement {
+            span: Span::new(0, 10),
+            table: qualified("t"),
+            columns: vec![Identifier::new("id".to_string())],
+            source: InsertSource::Values(vec![vec![int_expr(1)]]),
+            on_conflict: None,
+        };
+        let cloned = stmt.clone();
+        assert_eq!(stmt, cloned);
+    }
+
+    // ===== Task 4.3: INSERT ... SELECT (nested subquery) =====
+
+    #[test]
+    fn insert_select_from_plain_table() {
+        // INSERT INTO archive (id) SELECT id FROM source
+        let sel = SelectStatement {
+            span: Span::new(0, 30),
+            with: None,
+            projection: vec![SelectItem::Expression {
+                expr: ident_expr("id"),
+                alias: None,
+            }],
+            from: Some(table_factor("source")),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+        };
+        let stmt = InsertStatement {
+            span: Span::new(0, 50),
+            table: qualified("archive"),
+            columns: vec![Identifier::new("id".to_string())],
+            source: InsertSource::Select(Box::new(sel)),
+            on_conflict: None,
+        };
+        // Clone + PartialEq survive the Select(SelectStatement) recursion.
+        let cloned = stmt.clone();
+        assert_eq!(stmt, cloned);
+        assert!(matches!(stmt.source, InsertSource::Select(_)));
+    }
+
+    #[test]
+    fn insert_select_from_derived_subquery_recursion() {
+        // INSERT INTO t (x) SELECT x FROM (SELECT * FROM base JOIN other ON ...) AS sub
+        // Proves Clone/PartialEq survive the TableFactor::Derived -> Join recursion
+        // inside the InsertSource::Select branch of an INSERT node.
+        let inner_join = Join {
+            span: Span::new(0, 30),
+            join_type: JoinType::Inner,
+            table: table_factor("other"),
+            condition: JoinCondition::On(ident_expr("base.id")),
+            lateral: false,
+        };
+        let inner_select = SelectStatement {
+            span: Span::new(0, 50),
+            with: None,
+            projection: vec![SelectItem::Wildcard],
+            from: Some(TableFactor::Join(Box::new(inner_join))),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+        };
+        let middle_select = SelectStatement {
+            span: Span::new(0, 80),
+            with: None,
+            projection: vec![SelectItem::Expression {
+                expr: ident_expr("x"),
+                alias: None,
+            }],
+            from: Some(TableFactor::Derived {
+                subquery: Box::new(inner_select),
+                alias: Some(TableAlias::new("sub".to_string(), vec![])),
+            }),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+        };
+        let insert = InsertStatement {
+            span: Span::new(0, 100),
+            table: qualified("t"),
+            columns: vec![Identifier::new("x".to_string())],
+            source: InsertSource::Select(Box::new(middle_select)),
+            on_conflict: None,
+        };
+        let cloned = insert.clone();
+        assert_eq!(insert, cloned);
+        if let InsertSource::Select(sel) = &insert.source {
+            if let Some(TableFactor::Derived { alias, .. }) = &sel.from {
+                assert_eq!(alias.as_ref().expect("alias").name(), "sub");
+            } else {
+                panic!("expected Derived factor in INSERT...SELECT source");
+            }
+        } else {
+            panic!("expected Select source");
+        }
+    }
+
+    // ===== Task 4.3: UPDATE statement =====
+
+    #[test]
+    fn update_basic_assignments() {
+        // UPDATE users SET name = 'x', count = count + 1 WHERE id = 5
+        let stmt = UpdateStatement {
+            span: Span::new(0, 60),
+            table: table_factor("users"),
+            assignments: vec![
+                Assignment {
+                    column: Identifier::new("name".to_string()),
+                    value: ident_expr("x"),
+                },
+                Assignment {
+                    column: Identifier::new("count".to_string()),
+                    value: Expression::BinaryOp {
+                        left: Box::new(ident_expr("count")),
+                        op: BinaryOperator::Add,
+                        right: Box::new(int_expr(1)),
+                    },
+                },
+            ],
+            from: None,
+            where_clause: Some(Expression::Comparison {
+                left: Box::new(ident_expr("id")),
+                op: ComparisonOperator::Eq,
+                right: Box::new(int_expr(5)),
+            }),
+        };
+        assert_eq!(stmt.assignments.len(), 2);
+        assert!(stmt.from.is_none());
+        assert!(stmt.where_clause.is_some());
+    }
+
+    #[test]
+    fn update_with_from_clause() {
+        // UPDATE t SET ... FROM other WHERE t.id = other.id  (T-SQL / PostgreSQL)
+        let stmt = UpdateStatement {
+            span: Span::new(0, 40),
+            table: table_factor("t"),
+            assignments: vec![Assignment {
+                column: Identifier::new("val".to_string()),
+                value: ident_expr("other.val"),
+            }],
+            from: Some(table_factor("other")),
+            where_clause: None,
+        };
+        assert!(stmt.from.is_some());
+        assert!(stmt.where_clause.is_none());
+    }
+
+    #[test]
+    fn update_with_subquery_in_where() {
+        // UPDATE t SET val = 1 WHERE id IN (SELECT id FROM src)
+        // Proves Clone/PartialEq survive an Expression subquery inside the
+        // new UpdateStatement node.
+        let sub = SelectStatement {
+            span: Span::new(0, 30),
+            with: None,
+            projection: vec![SelectItem::Expression {
+                expr: ident_expr("id"),
+                alias: None,
+            }],
+            from: Some(table_factor("src")),
+            where_clause: None,
+            group_by: None,
+            having: None,
+            order_by: None,
+            limit: None,
+        };
+        let where_clause = Expression::In {
+            expr: Box::new(ident_expr("id")),
+            list: InList::Subquery(Box::new(sub)),
+            negated: false,
+        };
+        let stmt = UpdateStatement {
+            span: Span::new(0, 60),
+            table: table_factor("t"),
+            assignments: vec![Assignment {
+                column: Identifier::new("val".to_string()),
+                value: int_expr(1),
+            }],
+            from: None,
+            where_clause: Some(where_clause),
+        };
+        let cloned = stmt.clone();
+        assert_eq!(stmt, cloned);
+        assert!(stmt.where_clause.is_some());
+    }
+
+    #[test]
+    fn update_no_assignments_edge_case() {
+        // Edge case: UPDATE with no assignments (degenerate but representable).
+        let stmt = UpdateStatement {
+            span: Span::new(0, 10),
+            table: table_factor("t"),
+            assignments: vec![],
+            from: None,
+            where_clause: None,
+        };
+        assert!(stmt.assignments.is_empty());
+    }
+
+    // ===== Task 4.3: DELETE statement =====
+
+    #[test]
+    fn delete_basic_with_where() {
+        // DELETE FROM users WHERE id = 5
+        let stmt = DeleteStatement {
+            span: Span::new(0, 30),
+            table: table_factor("users"),
+            using: None,
+            where_clause: Some(Expression::Comparison {
+                left: Box::new(ident_expr("id")),
+                op: ComparisonOperator::Eq,
+                right: Box::new(int_expr(5)),
+            }),
+        };
+        assert!(stmt.using.is_none());
+        assert!(stmt.where_clause.is_some());
+    }
+
+    #[test]
+    fn delete_with_using_clause() {
+        // DELETE FROM t USING other WHERE t.id = other.id  (PostgreSQL USING)
+        let stmt = DeleteStatement {
+            span: Span::new(0, 40),
+            table: table_factor("t"),
+            using: Some(vec![table_factor("other")]),
+            where_clause: None,
+        };
+        let using = stmt.using.as_ref().expect("using");
+        assert_eq!(using.len(), 1);
+    }
+
+    #[test]
+    fn delete_multiple_using_tables() {
+        // DELETE FROM t USING a, b WHERE ...
+        let stmt = DeleteStatement {
+            span: Span::new(0, 50),
+            table: table_factor("t"),
+            using: Some(vec![table_factor("a"), table_factor("b")]),
+            where_clause: None,
+        };
+        let using = stmt.using.as_ref().expect("using");
+        assert_eq!(using.len(), 2);
+    }
+
+    #[test]
+    fn delete_without_where_deletes_all() {
+        // Edge case: DELETE FROM t  (no WHERE, deletes all rows)
+        let stmt = DeleteStatement {
+            span: Span::new(0, 10),
+            table: table_factor("t"),
+            using: None,
+            where_clause: None,
+        };
+        assert!(stmt.where_clause.is_none());
+    }
+
+    #[test]
+    fn delete_clone_equality() {
+        let stmt = DeleteStatement {
+            span: Span::new(0, 20),
+            table: table_factor("t"),
+            using: Some(vec![table_factor("a")]),
+            where_clause: Some(ident_expr("flag")),
+        };
+        let cloned = stmt.clone();
+        assert_eq!(stmt, cloned);
+    }
+
+    // ===== Task 4.3: Statement enum discriminants =====
+
+    #[test]
+    fn statement_insert_wraps_insert_statement() {
+        let inner = InsertStatement {
+            span: Span::new(0, 10),
+            table: qualified("t"),
+            columns: vec![],
+            source: InsertSource::Values(vec![]),
+            on_conflict: None,
+        };
+        let stmt = Statement::Insert(Box::new(inner));
+        assert!(matches!(stmt, Statement::Insert(_)));
+        assert!(!matches!(stmt, Statement::Select(_)));
+        assert!(!matches!(stmt, Statement::Update(_)));
+        assert!(!matches!(stmt, Statement::Delete(_)));
+        assert_eq!(stmt.clone(), stmt);
+    }
+
+    #[test]
+    fn statement_update_wraps_update_statement() {
+        let inner = UpdateStatement {
+            span: Span::new(0, 10),
+            table: table_factor("t"),
+            assignments: vec![],
+            from: None,
+            where_clause: None,
+        };
+        let stmt = Statement::Update(Box::new(inner));
+        assert!(matches!(stmt, Statement::Update(_)));
+        assert!(!matches!(stmt, Statement::Select(_)));
+        assert!(!matches!(stmt, Statement::Insert(_)));
+        assert!(!matches!(stmt, Statement::Delete(_)));
+        assert_eq!(stmt.clone(), stmt);
+    }
+
+    #[test]
+    fn statement_delete_wraps_delete_statement() {
+        let inner = DeleteStatement {
+            span: Span::new(0, 10),
+            table: table_factor("t"),
+            using: None,
+            where_clause: None,
+        };
+        let stmt = Statement::Delete(Box::new(inner));
+        assert!(matches!(stmt, Statement::Delete(_)));
+        assert!(!matches!(stmt, Statement::Select(_)));
+        assert!(!matches!(stmt, Statement::Insert(_)));
+        assert!(!matches!(stmt, Statement::Update(_)));
+        assert_eq!(stmt.clone(), stmt);
     }
 }

--- a/crates/common-sql/src/lib.rs
+++ b/crates/common-sql/src/lib.rs
@@ -1,0 +1,13 @@
+//! # Common SQL AST
+//!
+//! Dialect-independent SQL AST for transpilation.
+//! This crate defines the shared intermediate representation used by
+//! all SQL emitters (MySQL, PostgreSQL, SQLite).
+
+#![warn(missing_docs)]
+// workspace.lints から clippy 設定を継承
+#![warn(clippy::unwrap_used)]
+#![warn(clippy::expect_used)]
+#![warn(clippy::panic)]
+
+pub mod ast;

--- a/crates/common-sql/src/lib.rs
+++ b/crates/common-sql/src/lib.rs
@@ -11,3 +11,6 @@
 #![warn(clippy::panic)]
 
 pub mod ast;
+pub mod visitor;
+
+pub use visitor::{Visitable, Visitor};

--- a/crates/common-sql/src/visitor.rs
+++ b/crates/common-sql/src/visitor.rs
@@ -37,6 +37,16 @@ use crate::ast::Expression;
 /// `Visitor` is implemented for `&mut T`-style consumers: the trait is generic
 /// over `Sized` self and methods take `&mut self` so visitors can accumulate
 /// state (e.g. a `String` buffer) across nodes.
+///
+/// **Default methods are dispatch-only**: each `visit_*` hook routes a node to
+/// its matching override but does NOT descend into child nodes — e.g.
+/// [`visit_create_table_statement`](Self::visit_create_table_statement) does
+/// not walk `columns`/`constraints`, and
+/// [`visit_comparison`](Self::visit_comparison) does not recurse into
+/// `left`/`right`. An emitter that needs traversal must override the hook and
+/// call [`visit_expression`](Self::visit_expression) /
+/// [`visit_data_type`](Self::visit_data_type) itself. Centralized `walk_*`
+/// helpers may be added when the first downstream emitter lands.
 pub trait Visitor: Sized {
     /// The value produced by visiting a node.
     type Output;

--- a/crates/common-sql/src/visitor.rs
+++ b/crates/common-sql/src/visitor.rs
@@ -1,0 +1,729 @@
+//! Visitor pattern for the dialect-independent SQL AST.
+//!
+//! Provides a [`Visitor`] trait with default implementations for every AST
+//! node kind (Statement, Expression, DataType), and a [`Visitable`] trait
+//! implemented by the three root node types. Emitters (MySQL, PostgreSQL,
+//! SQLite) implement `Visitor` and override only the methods they care about;
+//! adding a new AST variant does not require touching existing visitors
+//! (open-closed principle).
+//!
+//! The result type is intentionally generic (`type Output`) so each visitor
+//! chooses its own return shape (e.g. `String`, `Result<String, E>`). When the
+//! first downstream emitter lands, revisit whether `Output` should be pinned
+//! to `Result<String, E>` — documented decision point, not a blocker now.
+
+use crate::ast::datatype::DataType;
+use crate::ast::ddl::{
+    AlterTableStatement, CreateIndexStatement, CreateTableStatement, DropIndexStatement,
+    DropTableStatement,
+};
+use crate::ast::expression::{
+    BinaryOperator, ComparisonOperator, InList, LogicalOperator, UnaryOperator,
+};
+use crate::ast::identifier::Identifier;
+use crate::ast::literal::Literal;
+use crate::ast::statement::{
+    DeleteStatement, InsertStatement, SelectStatement, Statement, UpdateStatement,
+};
+use crate::ast::Expression;
+
+/// AST visitor.
+///
+/// Every method has a default implementation that returns
+/// [`default_output`](Self::default_output), so a visitor only overrides the
+/// node kinds it needs. The associated [`Output`](Self::Output) type is chosen
+/// by the implementor.
+///
+/// `Visitor` is implemented for `&mut T`-style consumers: the trait is generic
+/// over `Sized` self and methods take `&mut self` so visitors can accumulate
+/// state (e.g. a `String` buffer) across nodes.
+pub trait Visitor: Sized {
+    /// The value produced by visiting a node.
+    type Output;
+
+    /// The default value returned when a visitor does not override a node's
+    /// `visit_*` method.
+    fn default_output(&self) -> Self::Output;
+
+    /// Dispatch a [`Statement`] to the matching `visit_*_statement` hook.
+    fn visit_statement(&mut self, stmt: &Statement) -> Self::Output {
+        match stmt {
+            Statement::Select(s) => self.visit_select_statement(s),
+            Statement::Insert(s) => self.visit_insert_statement(s),
+            Statement::Update(s) => self.visit_update_statement(s),
+            Statement::Delete(s) => self.visit_delete_statement(s),
+            Statement::CreateTable(s) => self.visit_create_table_statement(s),
+            Statement::AlterTable(s) => self.visit_alter_table_statement(s),
+            Statement::DropTable(s) => self.visit_drop_table_statement(s),
+            Statement::CreateIndex(s) => self.visit_create_index_statement(s),
+            Statement::DropIndex(s) => self.visit_drop_index_statement(s),
+        }
+    }
+
+    /// Visit a `SELECT` statement (default: [`default_output`](Self::default_output)).
+    fn visit_select_statement(&mut self, _stmt: &SelectStatement) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit an `INSERT` statement (default: [`default_output`](Self::default_output)).
+    fn visit_insert_statement(&mut self, _stmt: &InsertStatement) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit an `UPDATE` statement (default: [`default_output`](Self::default_output)).
+    fn visit_update_statement(&mut self, _stmt: &UpdateStatement) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a `DELETE` statement (default: [`default_output`](Self::default_output)).
+    fn visit_delete_statement(&mut self, _stmt: &DeleteStatement) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a `CREATE TABLE` statement (default: [`default_output`](Self::default_output)).
+    fn visit_create_table_statement(&mut self, _stmt: &CreateTableStatement) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit an `ALTER TABLE` statement (default: [`default_output`](Self::default_output)).
+    fn visit_alter_table_statement(&mut self, _stmt: &AlterTableStatement) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a `DROP TABLE` statement (default: [`default_output`](Self::default_output)).
+    fn visit_drop_table_statement(&mut self, _stmt: &DropTableStatement) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a `CREATE INDEX` statement (default: [`default_output`](Self::default_output)).
+    fn visit_create_index_statement(&mut self, _stmt: &CreateIndexStatement) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a `DROP INDEX` statement (default: [`default_output`](Self::default_output)).
+    fn visit_drop_index_statement(&mut self, _stmt: &DropIndexStatement) -> Self::Output {
+        self.default_output()
+    }
+
+    /// Dispatch an [`Expression`] to the matching `visit_*` hook.
+    fn visit_expression(&mut self, expr: &Expression) -> Self::Output {
+        match expr {
+            Expression::Literal(l) => self.visit_literal(l),
+            Expression::Identifier(i) => self.visit_identifier(i),
+            Expression::QualifiedIdentifier { table, column } => {
+                self.visit_qualified_identifier(table, column)
+            }
+            Expression::BinaryOp { left, op, right } => self.visit_binary_op(left, *op, right),
+            Expression::UnaryOp { op, expr } => self.visit_unary_op(*op, expr),
+            Expression::LogicalOp { left, op, right } => self.visit_logical_op(left, *op, right),
+            Expression::Comparison { left, op, right } => self.visit_comparison(left, *op, right),
+            Expression::Function {
+                name,
+                args,
+                distinct,
+            } => self.visit_function(name, args, *distinct),
+            Expression::Case {
+                operand,
+                conditions,
+                else_result,
+            } => self.visit_case(operand, conditions, else_result),
+            Expression::Subquery(sq) => self.visit_subquery(sq),
+            Expression::Exists { subquery, negated } => self.visit_exists(subquery, *negated),
+            Expression::In {
+                expr,
+                list,
+                negated,
+            } => self.visit_in(expr, list, *negated),
+            Expression::Between {
+                expr,
+                low,
+                high,
+                negated,
+            } => self.visit_between(expr, low, high, *negated),
+            Expression::Cast { expr, data_type } => self.visit_cast(expr, data_type),
+            Expression::IsNull { expr, negated } => self.visit_is_null(expr, *negated),
+        }
+    }
+
+    /// Visit a literal (default: [`default_output`](Self::default_output)).
+    fn visit_literal(&mut self, _literal: &Literal) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a simple identifier (default: [`default_output`](Self::default_output)).
+    fn visit_identifier(&mut self, _ident: &Identifier) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a `table.column` qualified identifier (default: [`default_output`](Self::default_output)).
+    fn visit_qualified_identifier(
+        &mut self,
+        _table: &Identifier,
+        _column: &Identifier,
+    ) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a binary operation (default: [`default_output`](Self::default_output)).
+    fn visit_binary_op(
+        &mut self,
+        _left: &Expression,
+        _op: BinaryOperator,
+        _right: &Expression,
+    ) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a unary operation (default: [`default_output`](Self::default_output)).
+    fn visit_unary_op(&mut self, _op: UnaryOperator, _expr: &Expression) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a logical connective (default: [`default_output`](Self::default_output)).
+    fn visit_logical_op(
+        &mut self,
+        _left: &Expression,
+        _op: LogicalOperator,
+        _right: &Expression,
+    ) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a comparison (default: [`default_output`](Self::default_output)).
+    fn visit_comparison(
+        &mut self,
+        _left: &Expression,
+        _op: ComparisonOperator,
+        _right: &Expression,
+    ) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a function call (default: [`default_output`](Self::default_output)).
+    fn visit_function(
+        &mut self,
+        _name: &Identifier,
+        _args: &[Expression],
+        _distinct: bool,
+    ) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a `CASE` expression (default: [`default_output`](Self::default_output)).
+    fn visit_case(
+        &mut self,
+        _operand: &Option<Box<Expression>>,
+        _conditions: &[(Expression, Expression)],
+        _else_result: &Option<Box<Expression>>,
+    ) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a scalar subquery (default: [`default_output`](Self::default_output)).
+    fn visit_subquery(&mut self, _subquery: &SelectStatement) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit an `EXISTS` expression (default: [`default_output`](Self::default_output)).
+    fn visit_exists(&mut self, _subquery: &SelectStatement, _negated: bool) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit an `IN` expression (default: [`default_output`](Self::default_output)).
+    fn visit_in(&mut self, _expr: &Expression, _list: &InList, _negated: bool) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a `BETWEEN` expression (default: [`default_output`](Self::default_output)).
+    fn visit_between(
+        &mut self,
+        _expr: &Expression,
+        _low: &Expression,
+        _high: &Expression,
+        _negated: bool,
+    ) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit a `CAST` expression (default: [`default_output`](Self::default_output)).
+    fn visit_cast(&mut self, _expr: &Expression, _data_type: &DataType) -> Self::Output {
+        self.default_output()
+    }
+    /// Visit an `IS NULL` expression (default: [`default_output`](Self::default_output)).
+    fn visit_is_null(&mut self, _expr: &Expression, _negated: bool) -> Self::Output {
+        self.default_output()
+    }
+
+    /// Visit a [`DataType`] (default: [`default_output`](Self::default_output)).
+    fn visit_data_type(&mut self, _data_type: &DataType) -> Self::Output {
+        self.default_output()
+    }
+}
+
+/// A node that can accept a [`Visitor`].
+///
+/// Implemented by the three root AST node kinds ([`Statement`], [`Expression`],
+/// [`DataType`]) so a caller can uniformly drive any of them through a visitor
+/// via `node.accept(&mut visitor)`.
+pub trait Visitable {
+    /// Drive `visitor` over this node and return its result.
+    fn accept<V: Visitor>(&self, visitor: &mut V) -> V::Output;
+}
+
+impl Visitable for Statement {
+    fn accept<V: Visitor>(&self, visitor: &mut V) -> V::Output {
+        visitor.visit_statement(self)
+    }
+}
+
+impl Visitable for Expression {
+    fn accept<V: Visitor>(&self, visitor: &mut V) -> V::Output {
+        visitor.visit_expression(self)
+    }
+}
+
+impl Visitable for DataType {
+    fn accept<V: Visitor>(&self, visitor: &mut V) -> V::Output {
+        visitor.visit_data_type(self)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::ast::ddl::{
+        AlterTableAction, ColumnConstraint, ColumnDef, IndexColumn, TableOptions,
+    };
+    use crate::ast::expression::{
+        BinaryOperator as BinOp, ComparisonOperator as CmpOp, InList, LogicalOperator as LogOp,
+        UnaryOperator as UnOp,
+    };
+    use crate::ast::identifier::QualifiedName;
+    use crate::ast::literal::Literal;
+    use crate::ast::span::Span;
+    use crate::ast::statement::{InsertSource, SelectItem};
+    use std::cell::Cell;
+
+    // A counting visitor that records how often each dispatch path fires.
+    // The trait's `default_output` takes `&self` (per the design contract), so
+    // the counters use `Cell` for interior mutability. We do NOT override the
+    // `visit_statement` / `visit_expression` dispatchers — we let them fall
+    // through to the per-variant hooks, which default to `default_output`.
+    // Overriding only `visit_data_type` proves the DataType path is distinct.
+
+    struct CountingVisitor {
+        data_types: Cell<u32>,
+        default_calls: Cell<u32>,
+    }
+
+    impl CountingVisitor {
+        fn new() -> Self {
+            Self {
+                data_types: Cell::new(0),
+                default_calls: Cell::new(0),
+            }
+        }
+
+        fn data_types(&self) -> u32 {
+            self.data_types.get()
+        }
+
+        fn default_calls(&self) -> u32 {
+            self.default_calls.get()
+        }
+    }
+
+    impl Visitor for CountingVisitor {
+        type Output = ();
+
+        fn default_output(&self) -> Self::Output {
+            self.default_calls.set(self.default_calls.get() + 1);
+        }
+
+        // Override ONLY visit_data_type to prove it is a distinct dispatch
+        // path; every other node kind falls back to default_output.
+        fn visit_data_type(&mut self, _data_type: &DataType) -> Self::Output {
+            self.data_types.set(self.data_types.get() + 1);
+        }
+    }
+
+    fn ident(s: &str) -> Identifier {
+        Identifier::new(s.to_string())
+    }
+
+    fn qualified(s: &str) -> QualifiedName {
+        QualifiedName::new(None, s.to_string())
+    }
+
+    fn minimal_select() -> Statement {
+        Statement::Select(Box::new(SelectStatement::simple(vec![
+            SelectItem::Wildcard,
+        ])))
+    }
+
+    fn minimal_create_table() -> Statement {
+        Statement::CreateTable(Box::new(crate::ast::ddl::CreateTableStatement {
+            span: Span::new(0, 1),
+            if_not_exists: false,
+            temporary: false,
+            name: qualified("t"),
+            columns: vec![ColumnDef {
+                span: Span::new(0, 1),
+                name: ident("id"),
+                data_type: DataType::BigInt,
+                nullable: false,
+                default: None,
+                constraints: vec![ColumnConstraint::PrimaryKey],
+            }],
+            constraints: vec![],
+            options: TableOptions::default(),
+        }))
+    }
+
+    fn minimal_alter_table() -> Statement {
+        Statement::AlterTable(Box::new(crate::ast::ddl::AlterTableStatement {
+            span: Span::new(0, 1),
+            name: qualified("t"),
+            actions: vec![AlterTableAction::DropColumn(ident("c"))],
+        }))
+    }
+
+    fn minimal_drop_table() -> Statement {
+        Statement::DropTable(Box::new(crate::ast::ddl::DropTableStatement {
+            span: Span::new(0, 1),
+            if_exists: false,
+            names: vec![qualified("t")],
+        }))
+    }
+
+    fn minimal_create_index() -> Statement {
+        Statement::CreateIndex(Box::new(crate::ast::ddl::CreateIndexStatement {
+            span: Span::new(0, 1),
+            unique: false,
+            if_not_exists: false,
+            name: ident("idx"),
+            table: qualified("t"),
+            columns: vec![IndexColumn {
+                name: ident("c"),
+                direction: None,
+            }],
+        }))
+    }
+
+    fn minimal_drop_index() -> Statement {
+        Statement::DropIndex(Box::new(crate::ast::ddl::DropIndexStatement {
+            span: Span::new(0, 1),
+            if_exists: false,
+            name: ident("idx"),
+            table: None,
+        }))
+    }
+
+    fn minimal_insert() -> Statement {
+        Statement::Insert(Box::new(InsertStatement {
+            span: Span::new(0, 1),
+            table: qualified("t"),
+            columns: vec![],
+            source: InsertSource::Values(vec![]),
+            on_conflict: None,
+        }))
+    }
+
+    fn minimal_update() -> Statement {
+        Statement::Update(Box::new(crate::ast::statement::UpdateStatement {
+            span: Span::new(0, 1),
+            table: crate::ast::join::TableFactor::Table {
+                name: qualified("t"),
+                alias: None,
+            },
+            assignments: vec![],
+            from: None,
+            where_clause: None,
+        }))
+    }
+
+    fn minimal_delete() -> Statement {
+        Statement::Delete(Box::new(crate::ast::statement::DeleteStatement {
+            span: Span::new(0, 1),
+            table: crate::ast::join::TableFactor::Table {
+                name: qualified("t"),
+                alias: None,
+            },
+            using: None,
+            where_clause: None,
+        }))
+    }
+
+    // -- Visitable.accept dispatches each Statement variant -----------------
+
+    #[test]
+    fn statement_visitable_accept_dispatches_select() {
+        let mut v = CountingVisitor::new();
+        minimal_select().accept(&mut v);
+        assert_eq!(v.default_calls(), 1);
+        assert_eq!(v.data_types(), 0);
+    }
+
+    #[test]
+    fn statement_visitable_accept_dispatches_insert() {
+        let mut v = CountingVisitor::new();
+        minimal_insert().accept(&mut v);
+        assert_eq!(v.default_calls(), 1);
+    }
+
+    #[test]
+    fn statement_visitable_accept_dispatches_update() {
+        let mut v = CountingVisitor::new();
+        minimal_update().accept(&mut v);
+        assert_eq!(v.default_calls(), 1);
+    }
+
+    #[test]
+    fn statement_visitable_accept_dispatches_delete() {
+        let mut v = CountingVisitor::new();
+        minimal_delete().accept(&mut v);
+        assert_eq!(v.default_calls(), 1);
+    }
+
+    #[test]
+    fn statement_visitable_accept_dispatches_create_table() {
+        let mut v = CountingVisitor::new();
+        minimal_create_table().accept(&mut v);
+        assert_eq!(v.default_calls(), 1);
+    }
+
+    #[test]
+    fn statement_visitable_accept_dispatches_alter_table() {
+        let mut v = CountingVisitor::new();
+        minimal_alter_table().accept(&mut v);
+        assert_eq!(v.default_calls(), 1);
+    }
+
+    #[test]
+    fn statement_visitable_accept_dispatches_drop_table() {
+        let mut v = CountingVisitor::new();
+        minimal_drop_table().accept(&mut v);
+        assert_eq!(v.default_calls(), 1);
+    }
+
+    #[test]
+    fn statement_visitable_accept_dispatches_create_index() {
+        let mut v = CountingVisitor::new();
+        minimal_create_index().accept(&mut v);
+        assert_eq!(v.default_calls(), 1);
+    }
+
+    #[test]
+    fn statement_visitable_accept_dispatches_drop_index() {
+        let mut v = CountingVisitor::new();
+        minimal_drop_index().accept(&mut v);
+        assert_eq!(v.default_calls(), 1);
+    }
+
+    // -- visit_statement dispatches all 9 variants without panic -----------
+    #[test]
+    fn visit_statement_covers_all_nine_variants() {
+        let stmts = vec![
+            minimal_select(),
+            minimal_insert(),
+            minimal_update(),
+            minimal_delete(),
+            minimal_create_table(),
+            minimal_alter_table(),
+            minimal_drop_table(),
+            minimal_create_index(),
+            minimal_drop_index(),
+        ];
+        assert_eq!(stmts.len(), 9, "all 9 Statement variants must be exercised");
+        for stmt in &stmts {
+            let mut v = CountingVisitor::new();
+            stmt.accept(&mut v);
+            assert_eq!(v.default_calls(), 1, "variant {stmt:?} did not dispatch");
+        }
+    }
+
+    // -- Expression Visitable + visit_expression coverage -------------------
+
+    #[test]
+    fn expression_visitable_accept_dispatches_literal() {
+        let mut v = CountingVisitor::new();
+        let expr = Expression::Literal(Literal::Integer(7));
+        expr.accept(&mut v);
+        assert_eq!(v.default_calls(), 1);
+    }
+
+    #[test]
+    fn visit_expression_covers_identifier_and_qualified() {
+        let mut v = CountingVisitor::new();
+        Expression::Identifier(ident("a")).accept(&mut v);
+        Expression::QualifiedIdentifier {
+            table: ident("t"),
+            column: ident("c"),
+        }
+        .accept(&mut v);
+        assert_eq!(v.default_calls(), 2);
+    }
+
+    #[test]
+    fn visit_expression_covers_operator_variants() {
+        let mut v = CountingVisitor::new();
+        let leaf = Expression::Literal(Literal::Integer(1));
+        Expression::BinaryOp {
+            left: Box::new(leaf.clone()),
+            op: BinOp::Add,
+            right: Box::new(leaf.clone()),
+        }
+        .accept(&mut v);
+        Expression::UnaryOp {
+            op: UnOp::Minus,
+            expr: Box::new(leaf.clone()),
+        }
+        .accept(&mut v);
+        Expression::LogicalOp {
+            left: Box::new(leaf.clone()),
+            op: LogOp::And,
+            right: Box::new(leaf.clone()),
+        }
+        .accept(&mut v);
+        Expression::Comparison {
+            left: Box::new(leaf.clone()),
+            op: CmpOp::Eq,
+            right: Box::new(leaf),
+        }
+        .accept(&mut v);
+        assert_eq!(v.default_calls(), 4);
+    }
+
+    #[test]
+    fn visit_expression_covers_advanced_variants() {
+        let mut v = CountingVisitor::new();
+        let leaf = Expression::Literal(Literal::Integer(1));
+        Expression::Function {
+            name: ident("count"),
+            args: vec![leaf.clone()],
+            distinct: true,
+        }
+        .accept(&mut v);
+        Expression::Case {
+            operand: None,
+            conditions: vec![(leaf.clone(), leaf.clone())],
+            else_result: None,
+        }
+        .accept(&mut v);
+        Expression::Cast {
+            expr: Box::new(leaf.clone()),
+            data_type: DataType::Int,
+        }
+        .accept(&mut v);
+        // Cast routes to visit_cast (default), not visit_data_type, so the
+        // DataType inside it must NOT inflate the data_types counter.
+        assert_eq!(v.data_types(), 0);
+        assert_eq!(v.default_calls(), 3);
+    }
+
+    /// All 15 Expression variants are reachable through accept(). Building the
+    /// list forces a compile error if `visit_expression` ever drops an arm.
+    #[test]
+    fn visit_expression_covers_all_fifteen_variants() {
+        let sub = SelectStatement::simple(vec![SelectItem::Wildcard]);
+        let exprs = vec![
+            Expression::Literal(Literal::Integer(1)),
+            Expression::Identifier(ident("c")),
+            Expression::QualifiedIdentifier {
+                table: ident("t"),
+                column: ident("c"),
+            },
+            Expression::BinaryOp {
+                left: Box::new(Expression::Literal(Literal::Integer(1))),
+                op: BinOp::Add,
+                right: Box::new(Expression::Literal(Literal::Integer(2))),
+            },
+            Expression::UnaryOp {
+                op: UnOp::Plus,
+                expr: Box::new(Expression::Literal(Literal::Integer(1))),
+            },
+            Expression::LogicalOp {
+                left: Box::new(Expression::Literal(Literal::Boolean(true))),
+                op: LogOp::And,
+                right: Box::new(Expression::Literal(Literal::Boolean(false))),
+            },
+            Expression::Comparison {
+                left: Box::new(Expression::Identifier(ident("x"))),
+                op: CmpOp::Eq,
+                right: Box::new(Expression::Literal(Literal::Integer(1))),
+            },
+            Expression::Function {
+                name: ident("COUNT"),
+                args: vec![],
+                distinct: false,
+            },
+            Expression::Case {
+                operand: None,
+                conditions: vec![],
+                else_result: None,
+            },
+            Expression::Subquery(Box::new(sub.clone())),
+            Expression::Exists {
+                subquery: Box::new(sub.clone()),
+                negated: false,
+            },
+            Expression::In {
+                expr: Box::new(Expression::Identifier(ident("x"))),
+                list: InList::Values(vec![]),
+                negated: false,
+            },
+            Expression::Between {
+                expr: Box::new(Expression::Identifier(ident("x"))),
+                low: Box::new(Expression::Literal(Literal::Integer(1))),
+                high: Box::new(Expression::Literal(Literal::Integer(10))),
+                negated: false,
+            },
+            Expression::Cast {
+                expr: Box::new(Expression::Identifier(ident("x"))),
+                data_type: DataType::Int,
+            },
+            Expression::IsNull {
+                expr: Box::new(Expression::Identifier(ident("x"))),
+                negated: false,
+            },
+        ];
+        assert_eq!(
+            exprs.len(),
+            15,
+            "all 15 Expression variants must be exercised"
+        );
+        for e in &exprs {
+            let mut v = CountingVisitor::new();
+            e.accept(&mut v);
+            assert_eq!(v.default_calls(), 1, "variant not dispatched");
+        }
+    }
+
+    // -- DataType Visitable routes to the overridden hook -------------------
+
+    #[test]
+    fn datatype_visitable_accept_routes_to_visit_data_type() {
+        let mut v = CountingVisitor::new();
+        DataType::BigInt.accept(&mut v);
+        DataType::VarChar { length: Some(255) }.accept(&mut v);
+        assert_eq!(v.data_types(), 2);
+        assert_eq!(v.default_calls(), 0);
+    }
+
+    // -- Generic Output type: a String-returning visitor --------------------
+
+    struct StringVisitor;
+
+    impl Visitor for StringVisitor {
+        type Output = String;
+        fn default_output(&self) -> Self::Output {
+            String::from("default")
+        }
+        fn visit_identifier(&mut self, ident: &Identifier) -> Self::Output {
+            ident.value().to_string()
+        }
+        fn visit_data_type(&mut self, _data_type: &DataType) -> Self::Output {
+            String::from("datatype")
+        }
+    }
+
+    #[test]
+    fn visitor_with_string_output_uses_overridden_method() {
+        let mut v = StringVisitor;
+        let out = Expression::Identifier(ident("foo")).accept(&mut v);
+        assert_eq!(out, "foo");
+    }
+
+    #[test]
+    fn visitor_with_string_output_falls_back_to_default_for_select() {
+        let mut v = StringVisitor;
+        let out = minimal_select().accept(&mut v);
+        assert_eq!(out, "default");
+    }
+}

--- a/crates/common-sql/tests/reexport_ddl.rs
+++ b/crates/common-sql/tests/reexport_ddl.rs
@@ -1,0 +1,180 @@
+//! Task 5.1 / Task 4: verify DDL nodes are re-exported and reachable from the
+//! public surface, and that the `Statement` enum wires all five DDL variants.
+//!
+//! These imports go through `common_sql::ast::*` (the public surface). If the
+//! `mod.rs` `pub use ddl::*;` re-export is missing, or any DDL `Statement`
+//! variant is absent, this file fails to compile.
+
+#![allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
+
+use common_sql::ast::{
+    AlterTableAction, AlterTableStatement, ColumnConstraint, ColumnDef, CreateIndexStatement,
+    CreateTableStatement, DataType, DropIndexStatement, DropTableStatement, Expression, Identifier,
+    IndexColumn, QualifiedName, SelectItem, SortDirection, Statement, TableConstraint,
+    TableOptions,
+};
+// Literal is needed to build a DEFAULT expression inside ColumnDef.
+use common_sql::ast::Literal;
+use common_sql::ast::Span;
+
+fn ident(s: &str) -> Identifier {
+    Identifier::new(s.to_string())
+}
+
+fn qualified(s: &str) -> QualifiedName {
+    QualifiedName::new(None, s.to_string())
+}
+
+fn pk_column() -> ColumnDef {
+    ColumnDef {
+        span: Span::new(0, 10),
+        name: ident("id"),
+        data_type: DataType::BigInt,
+        nullable: false,
+        default: None,
+        constraints: vec![ColumnConstraint::PrimaryKey],
+    }
+}
+
+// ===== Reachability: every DDL type imports through the crate surface =====
+
+#[test]
+fn all_ddl_types_are_reachable_from_crate_root() {
+    // Touch every re-exported DDL type so a missing re-export fails the build.
+    let _col: ColumnDef = pk_column();
+    let _cc: ColumnConstraint = ColumnConstraint::Unique;
+    let _tc: TableConstraint = TableConstraint::PrimaryKey {
+        name: None,
+        columns: vec![ident("id")],
+    };
+    let _opts: TableOptions = TableOptions::default();
+    let _action: AlterTableAction = AlterTableAction::DropColumn(ident("c"));
+    let _idx_col: IndexColumn = IndexColumn {
+        name: ident("c"),
+        direction: None,
+    };
+    let _dir: SortDirection = SortDirection::Asc;
+}
+
+// ===== Statement enum wiring: all five DDL variants =====
+
+#[test]
+fn statement_create_table_wraps_create_table_statement() {
+    let inner = CreateTableStatement {
+        span: Span::new(0, 20),
+        if_not_exists: false,
+        temporary: false,
+        name: qualified("users"),
+        columns: vec![pk_column()],
+        constraints: vec![],
+        options: TableOptions::default(),
+    };
+    let stmt = Statement::CreateTable(Box::new(inner));
+    assert!(matches!(stmt, Statement::CreateTable(_)));
+    // DDL discriminants must be distinguishable from DML ones.
+    assert!(!matches!(stmt, Statement::Select(_)));
+    assert!(!matches!(stmt, Statement::Insert(_)));
+    // Clone + PartialEq survive the boxed DDL variant.
+    assert_eq!(stmt.clone(), stmt);
+}
+
+#[test]
+fn statement_alter_table_wraps_alter_table_statement() {
+    let inner = AlterTableStatement {
+        span: Span::new(0, 20),
+        name: qualified("users"),
+        actions: vec![AlterTableAction::AddColumn(ColumnDef {
+            span: Span::new(5, 20),
+            name: ident("email"),
+            data_type: DataType::VarChar { length: Some(255) },
+            nullable: true,
+            default: None,
+            constraints: vec![],
+        })],
+    };
+    let stmt = Statement::AlterTable(Box::new(inner));
+    assert!(matches!(stmt, Statement::AlterTable(_)));
+    assert_eq!(stmt.clone(), stmt);
+}
+
+#[test]
+fn statement_drop_table_wraps_drop_table_statement() {
+    let inner = DropTableStatement {
+        span: Span::new(0, 20),
+        if_exists: false,
+        names: vec![qualified("users")],
+    };
+    let stmt = Statement::DropTable(Box::new(inner));
+    assert!(matches!(stmt, Statement::DropTable(_)));
+    assert_eq!(stmt.clone(), stmt);
+}
+
+#[test]
+fn statement_create_index_wraps_create_index_statement() {
+    let inner = CreateIndexStatement {
+        span: Span::new(0, 40),
+        unique: true,
+        if_not_exists: false,
+        name: ident("uk_email"),
+        table: qualified("users"),
+        columns: vec![IndexColumn {
+            name: ident("email"),
+            direction: Some(SortDirection::Desc),
+        }],
+    };
+    let stmt = Statement::CreateIndex(Box::new(inner));
+    assert!(matches!(stmt, Statement::CreateIndex(_)));
+    assert_eq!(stmt.clone(), stmt);
+}
+
+#[test]
+fn statement_drop_index_wraps_drop_index_statement() {
+    let inner = DropIndexStatement {
+        span: Span::new(0, 20),
+        if_exists: false,
+        name: ident("uk_email"),
+        table: Some(qualified("users")),
+    };
+    let stmt = Statement::DropIndex(Box::new(inner));
+    assert!(matches!(stmt, Statement::DropIndex(_)));
+    assert_eq!(stmt.clone(), stmt);
+}
+
+// ===== End-to-end: a CREATE TABLE carrying a CHECK constraint + DEFAULT =====
+
+#[test]
+fn create_table_round_trips_with_constraint_and_default() {
+    let inner = CreateTableStatement {
+        span: Span::new(0, 80),
+        if_not_exists: true,
+        temporary: false,
+        name: qualified("accounts"),
+        columns: vec![
+            pk_column(),
+            ColumnDef {
+                span: Span::new(20, 40),
+                name: ident("balance"),
+                data_type: DataType::Int,
+                nullable: false,
+                default: Some(Expression::Literal(Literal::Integer(0))),
+                constraints: vec![ColumnConstraint::Check(Expression::Comparison {
+                    left: Box::new(Expression::Identifier(ident("balance"))),
+                    op: common_sql::ast::ComparisonOperator::Ge,
+                    right: Box::new(Expression::Literal(Literal::Integer(0))),
+                })],
+            },
+        ],
+        constraints: vec![],
+        options: TableOptions::default(),
+    };
+    let stmt = Statement::CreateTable(Box::new(inner));
+    // Force the wildcard re-export path to resolve every DDL symbol.
+    let cloned = stmt.clone();
+    assert_eq!(stmt, cloned);
+}
+
+// Keep SelectItem import used so the test file does not warn on it.
+#[test]
+fn _select_item_import_used() {
+    let _ = SelectItem::Wildcard;
+}

--- a/crates/common-sql/tests/reexport_dml.rs
+++ b/crates/common-sql/tests/reexport_dml.rs
@@ -1,0 +1,106 @@
+//! Task 4.3 / Task 3: verify DML nodes are re-exported from the crate root.
+//!
+//! These imports go through `common_sql::ast::*` (the public surface). If the
+//! `mod.rs` re-exports are missing, this file fails to compile.
+
+#![allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
+
+use common_sql::ast::{
+    Assignment, DeleteStatement, InsertSource, InsertStatement, OnConflict, Statement,
+    UpdateStatement,
+};
+use common_sql::ast::{
+    Expression, Identifier, Literal, QualifiedName, SelectItem, SelectStatement, Span, TableAlias,
+    TableFactor,
+};
+
+fn ident_expr(name: &str) -> Expression {
+    Expression::Identifier(Identifier::new(name.to_string()))
+}
+
+fn int_expr(n: i64) -> Expression {
+    Expression::Literal(Literal::Integer(n))
+}
+
+fn qualified(name: &str) -> QualifiedName {
+    QualifiedName::new(None, name.to_string())
+}
+
+fn table_factor(name: &str) -> TableFactor {
+    TableFactor::Table {
+        name: qualified(name),
+        alias: None,
+    }
+}
+
+#[test]
+fn insert_statement_is_reachable_and_buildable() {
+    let stmt = InsertStatement {
+        span: Span::new(0, 10),
+        table: qualified("users"),
+        columns: vec![Identifier::new("id".to_string())],
+        source: InsertSource::Values(vec![vec![int_expr(1)]]),
+        on_conflict: None,
+    };
+    let wrapped = Statement::Insert(Box::new(stmt.clone()));
+    assert!(matches!(wrapped, Statement::Insert(_)));
+    assert_eq!(wrapped.clone(), wrapped);
+}
+
+#[test]
+fn insert_source_select_variant_is_reachable() {
+    let inner = SelectStatement::simple(vec![SelectItem::Wildcard]);
+    let src = InsertSource::Select(Box::new(inner));
+    assert!(matches!(src, InsertSource::Select(_)));
+}
+
+#[test]
+fn update_statement_is_reachable_and_buildable() {
+    let stmt = UpdateStatement {
+        span: Span::new(0, 10),
+        table: table_factor("users"),
+        assignments: vec![Assignment {
+            column: Identifier::new("name".to_string()),
+            value: ident_expr("bob"),
+        }],
+        from: None,
+        where_clause: Some(ident_expr("cond")),
+    };
+    let wrapped = Statement::Update(Box::new(stmt));
+    assert!(matches!(wrapped, Statement::Update(_)));
+}
+
+#[test]
+fn delete_statement_is_reachable_and_buildable() {
+    let stmt = DeleteStatement {
+        span: Span::new(0, 10),
+        table: table_factor("users"),
+        using: None,
+        where_clause: Some(ident_expr("cond")),
+    };
+    let wrapped = Statement::Delete(Box::new(stmt));
+    assert!(matches!(wrapped, Statement::Delete(_)));
+}
+
+#[test]
+fn on_conflict_remains_reachable() {
+    let oc = OnConflict {
+        span: Span::new(0, 1),
+        action: common_sql::ast::ConflictAction::DoNothing,
+        conflict_target: None,
+    };
+    let ins = InsertStatement {
+        span: Span::new(0, 1),
+        table: qualified("t"),
+        columns: vec![],
+        source: InsertSource::Values(vec![]),
+        on_conflict: Some(oc),
+    };
+    assert!(ins.on_conflict.is_some());
+}
+
+// Touch TableAlias so the import is used regardless of fn bodies above.
+#[test]
+fn _table_alias_import_used() {
+    let _ = TableAlias::new("x".to_string(), vec![]);
+}

--- a/crates/common-sql/tests/scaffold_tests.rs
+++ b/crates/common-sql/tests/scaffold_tests.rs
@@ -226,7 +226,7 @@ mod tests {
     // ---------------------------------------------------------------
     #[test]
     fn test_statement_select_variant_exists() {
-        let stmt = Statement::Select(SelectStatement::simple(vec![]));
+        let stmt = Statement::Select(Box::new(SelectStatement::simple(vec![])));
         let _debug = format!("{stmt:?}");
         assert_eq!(stmt.clone(), stmt);
     }
@@ -262,6 +262,6 @@ mod tests {
         let _item = SelectItem::Wildcard;
         let _expr = Expression::Literal(Literal::Null);
         let _in_list = InList::Values(vec![]);
-        let _stmt = Statement::Select(SelectStatement::simple(vec![]));
+        let _stmt = Statement::Select(Box::new(SelectStatement::simple(vec![])));
     }
 }

--- a/crates/common-sql/tests/scaffold_tests.rs
+++ b/crates/common-sql/tests/scaffold_tests.rs
@@ -1,0 +1,267 @@
+//! Scaffold integration tests for common-sql crate.
+//!
+//! Verifies:
+//! - Crate compiles with zero external dependencies
+//! - Workspace lint inheritance works
+//! - All declared modules are accessible
+//! - Public re-exports are reachable from the crate root
+//! - Each type can be instantiated and has expected derives
+
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use common_sql::ast::{
+        BinaryOperator, ComparisonOperator, DataType, Expression, Identifier, InList, Literal,
+        LogicalOperator, Position, QualifiedName, SelectItem, SelectStatement, Span, Statement,
+        TableAlias, UnaryOperator,
+    };
+
+    // ---------------------------------------------------------------
+    // Test: Span can be constructed and has expected derives
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_span_new_and_derives() {
+        let span = Span::new(0, 5);
+        assert_eq!(span.start, 0);
+        assert_eq!(span.end, 5);
+
+        // Copy (implicit — Clone is also available via Copy)
+        let copied = span;
+        assert_eq!(span, copied);
+
+        // Debug
+        let _debug_str = format!("{span:?}");
+    }
+
+    #[test]
+    fn test_span_is_empty() {
+        let empty = Span::new(10, 10);
+        assert!(empty.is_empty());
+
+        let non_empty = Span::new(10, 20);
+        assert!(!non_empty.is_empty());
+    }
+
+    // ---------------------------------------------------------------
+    // Test: Position can be constructed
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_position_construction() {
+        let pos = Position::new(1, 1, 0);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 1);
+        assert_eq!(pos.offset, 0);
+
+        // Copy + Debug
+        let _copied = pos;
+        let _debug = format!("{pos:?}");
+    }
+
+    // ---------------------------------------------------------------
+    // Test: Identifier can be constructed
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_identifier_construction() {
+        let id = Identifier::new("users".to_string());
+        assert_eq!(id.value(), "users");
+        assert!(!id.quoted());
+
+        // Clone + Debug + PartialEq
+        let id2 = id.clone();
+        assert_eq!(id, id2);
+        let _debug = format!("{id:?}");
+    }
+
+    #[test]
+    fn test_identifier_quoted() {
+        let id = Identifier::new_quoted("name".to_string());
+        assert_eq!(id.value(), "name");
+        assert!(id.quoted());
+    }
+
+    // ---------------------------------------------------------------
+    // Test: QualifiedName can be constructed
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_qualified_name_construction() {
+        let qn = QualifiedName::new(None, "users".to_string());
+        assert_eq!(qn.name(), "users");
+        assert!(qn.schema().is_none());
+
+        let qn_with_schema = QualifiedName::new(Some("dbo".to_string()), "users".to_string());
+        assert_eq!(qn_with_schema.schema(), Some("dbo"));
+    }
+
+    // ---------------------------------------------------------------
+    // Test: TableAlias can be constructed
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_table_alias_construction() {
+        let alias = TableAlias::new("u".to_string(), vec![]);
+        assert_eq!(alias.name(), "u");
+        assert!(alias.columns().is_empty());
+    }
+
+    // ---------------------------------------------------------------
+    // Test: Literal variants can be constructed
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_literal_integer() {
+        let lit = Literal::Integer(42);
+        let _debug = format!("{lit:?}");
+        let cloned = lit.clone();
+        assert_eq!(lit, cloned);
+    }
+
+    #[test]
+    fn test_literal_null() {
+        let lit = Literal::Null;
+        assert_eq!(lit, Literal::Null);
+    }
+
+    #[test]
+    fn test_literal_string() {
+        let lit = Literal::String("hello".to_string());
+        let _debug = format!("{lit:?}");
+    }
+
+    #[test]
+    fn test_literal_boolean() {
+        assert_eq!(Literal::Boolean(true), Literal::Boolean(true));
+    }
+
+    #[test]
+    fn test_literal_float() {
+        // Float is String-based per CTO review (preserves DECIMAL precision)
+        let lit = Literal::Float("3.14159".to_string());
+        let _debug = format!("{lit:?}");
+    }
+
+    // ---------------------------------------------------------------
+    // Test: Operator enums have expected derives
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_binary_operator_derives() {
+        let op = BinaryOperator::Add;
+        let copied = op;
+        assert_eq!(op, copied);
+        let _debug = format!("{op:?}");
+    }
+
+    #[test]
+    fn test_unary_operator_derives() {
+        let op = UnaryOperator::Minus;
+        assert_eq!(op, UnaryOperator::Minus);
+    }
+
+    #[test]
+    fn test_logical_operator_derives() {
+        assert_eq!(LogicalOperator::And, LogicalOperator::And);
+        assert_eq!(LogicalOperator::Or, LogicalOperator::Or);
+    }
+
+    #[test]
+    fn test_comparison_operator_derives() {
+        assert_eq!(ComparisonOperator::Eq, ComparisonOperator::Eq);
+    }
+
+    // ---------------------------------------------------------------
+    // Test: DataType has at least basic variants
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_data_type_basic_variants() {
+        let _int = DataType::Int;
+        let _text = DataType::Text;
+        let _bool = DataType::Boolean;
+        let _uuid = DataType::Uuid;
+        let _date = DataType::Date;
+    }
+
+    #[test]
+    fn test_data_type_varchar() {
+        let vc = DataType::VarChar { length: Some(255) };
+        let _debug = format!("{vc:?}");
+        assert_eq!(vc.clone(), vc);
+    }
+
+    // ---------------------------------------------------------------
+    // Test: SelectItem has expected variants
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_select_item_wildcard() {
+        let item = SelectItem::Wildcard;
+        let _debug = format!("{item:?}");
+        assert_eq!(item.clone(), item);
+    }
+
+    // ---------------------------------------------------------------
+    // Test: Expression::Literal variant works
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_expression_literal() {
+        let expr = Expression::Literal(Literal::Integer(1));
+        let _debug = format!("{expr:?}");
+        assert_eq!(expr.clone(), expr);
+    }
+
+    #[test]
+    fn test_expression_identifier() {
+        let expr = Expression::Identifier(Identifier::new("col".to_string()));
+        let _debug = format!("{expr:?}");
+    }
+
+    // ---------------------------------------------------------------
+    // Test: InList variants exist
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_in_list_variants() {
+        let values = InList::Values(vec![]);
+        let _debug = format!("{values:?}");
+        assert_eq!(values.clone(), values);
+    }
+
+    // ---------------------------------------------------------------
+    // Test: Statement has at least Select variant
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_statement_select_variant_exists() {
+        let stmt = Statement::Select(SelectStatement::simple(vec![]));
+        let _debug = format!("{stmt:?}");
+        assert_eq!(stmt.clone(), stmt);
+    }
+
+    // ---------------------------------------------------------------
+    // Test: Span default is zero-width at origin
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_span_default() {
+        let span = Span::default();
+        assert_eq!(span.start, 0);
+        assert_eq!(span.end, 0);
+        assert!(span.is_empty());
+    }
+
+    // ---------------------------------------------------------------
+    // Test: crate has no external dependencies (compile-time check)
+    // This is implicitly verified by the fact that we can use all
+    // types above without any external crate imports.
+    // ---------------------------------------------------------------
+    #[test]
+    fn test_no_external_dependency_imports() {
+        // If this compiles, the crate has zero external dependencies.
+        // All types used in this file come from common_sql::ast only.
+        let _span = Span::new(0, 0);
+        let _pos = Position::new(1, 1, 0);
+        let _id = Identifier::new("test".to_string());
+        let _qn = QualifiedName::new(None, "tbl".to_string());
+        let _alias = TableAlias::new("a".to_string(), vec![]);
+        let _lit = Literal::Integer(0);
+        let _op = BinaryOperator::Add;
+        let _dt = DataType::Int;
+        let _item = SelectItem::Wildcard;
+        let _expr = Expression::Literal(Literal::Null);
+        let _in_list = InList::Values(vec![]);
+        let _stmt = Statement::Select(SelectStatement::simple(vec![]));
+    }
+}

--- a/crates/common-sql/tests/visitor_tests.rs
+++ b/crates/common-sql/tests/visitor_tests.rs
@@ -1,0 +1,397 @@
+//! Task 6.2: integration tests driving a custom Visitor through
+//! `Visitable::accept` over a realistic AST.
+//!
+//! The AST built here mirrors what a transpiler actually sees:
+//!   1. A `CREATE TABLE` with a `PRIMARY KEY` column and a `FOREIGN KEY`
+//!      table constraint.
+//!   2. A `SELECT` whose `WHERE` clause is a `Comparison` whose right-hand
+//!      side is a `BinaryOp` (`price + tax`).
+//!   3. A `CAST` expression inside the projection.
+//!
+//! An `EmitStub` visitor records the order in which it dispatches to each
+//! node kind, producing a flat trace we assert against. This proves:
+//!   - `Visitable::accept` reaches the right per-variant hook for every
+//!     `Statement` and `Expression` variant touched.
+//!   - The default `visit_*` walk recurses into child nodes (a `Comparison`
+//!     visits its left/right operands; a `CAST` visits its inner expression
+//!     and data type).
+//!   - The generic `Output` type works for a non-trivial accumulator
+//!     (`Vec<&'static str>`), validating the open-closed contract that the
+//!     downstream emitters will rely on.
+
+#![allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
+
+use common_sql::ast::ddl::{AlterTableAction, AlterTableStatement};
+use common_sql::ast::ddl::{
+    ColumnConstraint, ColumnDef, CreateTableStatement, IndexColumn, TableConstraint, TableOptions,
+};
+use common_sql::ast::SortDirection as IndexSortDirection;
+use common_sql::ast::{
+    BinaryOperator, ComparisonOperator, DataType, Expression, Identifier, InsertSource,
+    InsertStatement, Literal, QualifiedName, SelectItem, SelectStatement, Span, Statement,
+    TableFactor,
+};
+use common_sql::{Visitable, Visitor};
+
+// ---------------------------------------------------------------------------
+// A stub emitter visitor that records its dispatch trace.
+// ---------------------------------------------------------------------------
+
+/// A visitor that appends a tag to a trace buffer for every node it dispatches
+/// to. It overrides the dispatch entry points and the per-variant hooks the
+/// realistic AST exercises, and recurses manually so the trace reflects true
+/// visitation order.
+struct EmitStub {
+    trace: Vec<&'static str>,
+}
+
+impl EmitStub {
+    fn new() -> Self {
+        Self { trace: Vec::new() }
+    }
+
+    fn tag(&mut self, name: &'static str) {
+        self.trace.push(name);
+    }
+}
+
+impl Visitor for EmitStub {
+    type Output = ();
+
+    fn default_output(&self) {}
+
+    // --- Statement dispatch: tag + recurse into the interesting children ---
+
+    fn visit_create_table_statement(&mut self, stmt: &CreateTableStatement) {
+        self.tag("create_table");
+        // Walk every column so the trace shows the column's data type.
+        for col in &stmt.columns {
+            self.tag("column");
+            self.visit_data_type(&col.data_type);
+        }
+        for c in &stmt.constraints {
+            self.tag("table_constraint");
+            // A FK references columns; we only tag, no deeper walk needed here.
+            if let TableConstraint::ForeignKey { ref_table, .. } = c {
+                let _ = ref_table.name();
+            }
+        }
+    }
+
+    fn visit_select_statement(&mut self, stmt: &SelectStatement) {
+        self.tag("select");
+        // Recurse into the WHERE clause if present.
+        if let Some(where_clause) = &stmt.where_clause {
+            self.tag("where");
+            self.visit_expression(where_clause);
+        }
+        // Recurse into projection items that carry an expression.
+        for item in &stmt.projection {
+            if let SelectItem::Expression { expr, .. } = item {
+                self.tag("projection");
+                self.visit_expression(expr);
+            }
+        }
+    }
+
+    fn visit_insert_statement(&mut self, _stmt: &InsertStatement) {
+        self.tag("insert");
+    }
+
+    fn visit_update_statement(&mut self, _stmt: &common_sql::ast::UpdateStatement) {
+        self.tag("update");
+    }
+
+    fn visit_delete_statement(&mut self, _stmt: &common_sql::ast::DeleteStatement) {
+        self.tag("delete");
+    }
+
+    // --- Expression dispatch: tag + recurse into operands -----------------
+
+    fn visit_comparison(&mut self, left: &Expression, _op: ComparisonOperator, right: &Expression) {
+        self.tag("comparison");
+        self.visit_expression(left);
+        self.visit_expression(right);
+    }
+
+    fn visit_binary_op(&mut self, left: &Expression, op: BinaryOperator, right: &Expression) {
+        // Tag the operator so we can assert which binary op was visited.
+        let op_tag = match op {
+            BinaryOperator::Add => "binary_add",
+            BinaryOperator::Sub => "binary_sub",
+            BinaryOperator::Mul => "binary_mul",
+            BinaryOperator::Div => "binary_div",
+            BinaryOperator::Mod => "binary_mod",
+            BinaryOperator::Concat => "binary_concat",
+        };
+        self.tag(op_tag);
+        self.visit_expression(left);
+        self.visit_expression(right);
+    }
+
+    fn visit_identifier(&mut self, _ident: &Identifier) {
+        self.tag("identifier");
+    }
+
+    fn visit_literal(&mut self, _literal: &Literal) {
+        self.tag("literal");
+    }
+
+    fn visit_cast(&mut self, expr: &Expression, data_type: &DataType) {
+        self.tag("cast");
+        self.visit_expression(expr);
+        self.visit_data_type(data_type);
+    }
+
+    fn visit_data_type(&mut self, _data_type: &DataType) {
+        self.tag("data_type");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AST builders
+// ---------------------------------------------------------------------------
+
+fn ident(s: &str) -> Identifier {
+    Identifier::new(s.to_string())
+}
+
+fn qualified(s: &str) -> QualifiedName {
+    QualifiedName::new(None, s.to_string())
+}
+
+fn id_expr(s: &str) -> Expression {
+    Expression::Identifier(ident(s))
+}
+
+fn int_expr(n: i64) -> Expression {
+    Expression::Literal(Literal::Integer(n))
+}
+
+fn table_factor(name: &str) -> TableFactor {
+    TableFactor::Table {
+        name: qualified(name),
+        alias: None,
+    }
+}
+
+/// Build `CREATE TABLE orders (id BIGINT PRIMARY KEY, user_id INT NOT NULL,
+/// CONSTRAINT fk_order_user FOREIGN KEY (user_id) REFERENCES users(id))`.
+fn create_table_with_pk_and_fk() -> Statement {
+    Statement::CreateTable(Box::new(CreateTableStatement {
+        span: Span::new(0, 120),
+        if_not_exists: false,
+        temporary: false,
+        name: qualified("orders"),
+        columns: vec![
+            ColumnDef {
+                span: Span::new(0, 20),
+                name: ident("id"),
+                data_type: DataType::BigInt,
+                nullable: false,
+                default: None,
+                constraints: vec![ColumnConstraint::PrimaryKey],
+            },
+            ColumnDef {
+                span: Span::new(20, 50),
+                name: ident("user_id"),
+                data_type: DataType::Int,
+                nullable: false,
+                default: None,
+                constraints: vec![ColumnConstraint::References {
+                    table: qualified("users"),
+                    columns: vec!["id".to_string()],
+                }],
+            },
+        ],
+        constraints: vec![TableConstraint::ForeignKey {
+            name: Some("fk_order_user".to_string()),
+            columns: vec![ident("user_id")],
+            ref_table: qualified("users"),
+            ref_columns: vec![ident("id")],
+        }],
+        options: TableOptions::default(),
+    }))
+}
+
+/// Build `SELECT CAST(price AS DECIMAL(18,2)) FROM orders
+///        WHERE total = price + tax`.
+fn select_with_where_binaryop_and_cast() -> Statement {
+    // right-hand side of the WHERE comparison: price + tax
+    let binary_rhs = Expression::BinaryOp {
+        left: Box::new(id_expr("price")),
+        op: BinaryOperator::Add,
+        right: Box::new(id_expr("tax")),
+    };
+    // WHERE total = price + tax
+    let where_clause = Expression::Comparison {
+        left: Box::new(id_expr("total")),
+        op: ComparisonOperator::Eq,
+        right: Box::new(binary_rhs),
+    };
+    // projection: CAST(price AS DECIMAL(18,2))
+    let cast_expr = Expression::Cast {
+        expr: Box::new(id_expr("price")),
+        data_type: DataType::Decimal {
+            precision: Some(18),
+            scale: Some(2),
+        },
+    };
+    let select = SelectStatement {
+        span: Span::new(0, 80),
+        with: None,
+        projection: vec![SelectItem::Expression {
+            expr: cast_expr,
+            alias: None,
+        }],
+        from: Some(table_factor("orders")),
+        where_clause: Some(where_clause),
+        group_by: None,
+        having: None,
+        order_by: None,
+        limit: None,
+    };
+    Statement::Select(Box::new(select))
+}
+
+fn insert_stub() -> Statement {
+    Statement::Insert(Box::new(InsertStatement {
+        span: Span::new(0, 10),
+        table: qualified("orders"),
+        columns: vec![ident("id")],
+        source: InsertSource::Values(vec![vec![int_expr(1)]]),
+        on_conflict: None,
+    }))
+}
+
+fn alter_table_stub() -> Statement {
+    Statement::AlterTable(Box::new(AlterTableStatement {
+        span: Span::new(0, 10),
+        name: qualified("orders"),
+        actions: vec![AlterTableAction::DropColumn(ident("user_id"))],
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests: node visit order through Visitable::accept
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_table_visitor_records_columns_and_constraints_in_order() {
+    let stmt = create_table_with_pk_and_fk();
+    let mut v = EmitStub::new();
+    let () = stmt.accept(&mut v);
+    // create_table -> column(id) -> BigInt -> column(user_id) -> Int -> fk
+    assert_eq!(
+        v.trace,
+        vec![
+            "create_table",
+            "column",
+            "data_type", // id BIGINT
+            "column",
+            "data_type",        // user_id INT
+            "table_constraint", // FOREIGN KEY
+        ]
+    );
+}
+
+#[test]
+fn select_visitor_walks_where_comparison_then_projection_cast() {
+    let stmt = select_with_where_binaryop_and_cast();
+    let mut v = EmitStub::new();
+    let () = stmt.accept(&mut v);
+    // select -> where -> comparison(total, binary_add(price, tax))
+    //        -> projection -> cast(price) -> Decimal
+    assert_eq!(
+        v.trace,
+        vec![
+            "select",
+            "where",
+            "comparison",
+            "identifier", // total (left)
+            "binary_add",
+            "identifier", // price
+            "identifier", // tax
+            "projection",
+            "cast",
+            "identifier", // price (cast operand)
+            "data_type",  // DECIMAL(18,2)
+        ]
+    );
+}
+
+#[test]
+fn cast_expression_alone_visits_inner_expr_and_data_type() {
+    // CAST(x AS INT) driven directly through Expression::accept.
+    let expr = Expression::Cast {
+        expr: Box::new(id_expr("x")),
+        data_type: DataType::Int,
+    };
+    let mut v = EmitStub::new();
+    let () = expr.accept(&mut v);
+    assert_eq!(v.trace, vec!["cast", "identifier", "data_type"]);
+}
+
+#[test]
+fn data_type_is_visitable_and_routes_to_visit_data_type() {
+    let dt = DataType::VarChar { length: Some(255) };
+    let mut v = EmitStub::new();
+    let () = dt.accept(&mut v);
+    assert_eq!(v.trace, vec!["data_type"]);
+}
+
+#[test]
+fn insert_and_alter_dispatch_through_statement_accept() {
+    // INSERT and ALTER are only tagged at the top level (no recursion in the
+    // stub), proving accept reaches their per-variant hook.
+    let mut v = EmitStub::new();
+    insert_stub().accept(&mut v);
+    assert_eq!(v.trace.last(), Some(&"insert"));
+
+    let mut v2 = EmitStub::new();
+    alter_table_stub().accept(&mut v2);
+    // visit_alter_table_statement is not overridden, so it falls back to
+    // default_output (no tag) — but accept must still dispatch without panic.
+    assert!(v2.trace.is_empty());
+}
+
+#[test]
+fn visitor_generic_output_works_with_string_accumulator() {
+    // A different Output type (String) proves the trait is generic and an
+    // emitter can choose its own return shape.
+    struct StringEmit;
+    impl Visitor for StringEmit {
+        type Output = String;
+        fn default_output(&self) -> String {
+            String::from("d")
+        }
+        fn visit_identifier(&mut self, ident: &Identifier) -> String {
+            ident.value().to_string()
+        }
+        fn visit_create_table_statement(&mut self, _stmt: &CreateTableStatement) -> String {
+            String::from("CREATE TABLE")
+        }
+    }
+    let mut v = StringEmit;
+    // CREATE TABLE -> overridden -> "CREATE TABLE"
+    let out = create_table_with_pk_and_fk().accept(&mut v);
+    assert_eq!(out, "CREATE TABLE");
+    // An identifier expression routes to the overridden visit_identifier.
+    let out = id_expr("foo").accept(&mut v);
+    assert_eq!(out, "foo");
+    // A node kind with no override falls back to default_output.
+    let out = DataType::Int.accept(&mut v);
+    assert_eq!(out, "d");
+}
+
+#[test]
+fn index_sort_direction_alias_round_trips() {
+    // The ddl SortDirection (aliased to avoid clashing with clause::SortDirection)
+    // is reachable via the public surface and behaves as a Copy enum.
+    assert_eq!(IndexSortDirection::Asc, IndexSortDirection::Asc);
+    assert_ne!(IndexSortDirection::Asc, IndexSortDirection::Desc);
+    let _col = IndexColumn {
+        name: ident("c"),
+        direction: Some(IndexSortDirection::Desc),
+    };
+}

--- a/crates/tsql-parser/Cargo.toml
+++ b/crates/tsql-parser/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/Protom512/tsqlremaker"
 [dependencies]
 tsql-lexer = { path = "../tsql-lexer" }
 tsql-token = { path = "../tsql-token" }
+common-sql = { path = "../common-sql" }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tsql-parser/src/common/convert_common_sql.rs
+++ b/crates/tsql-parser/src/common/convert_common_sql.rs
@@ -9,9 +9,12 @@
 //! `DOUBLE PRECISION` only); it maps to `DoublePrecision` with its precision
 //! discarded, which is range-safe for typical values.
 
-use common_sql::ast::DataType as SqlDataType;
+use common_sql::ast::{
+    DataType as SqlDataType, Identifier as SqlIdentifier, Literal as SqlLiteral,
+    UnaryOperator as SqlUnaryOperator,
+};
 
-use crate::common::CommonDataType;
+use crate::common::{CommonDataType, CommonIdentifier, CommonLiteral, CommonUnaryOperator};
 
 /// Convert a legacy [`CommonDataType`] into the standalone
 /// [`common_sql::ast::DataType`].
@@ -53,12 +56,100 @@ impl From<CommonDataType> for SqlDataType {
     }
 }
 
+/// Convert a legacy [`CommonLiteral`] into the standalone
+/// [`common_sql::ast::Literal`].
+///
+/// `Float(f64)` is rendered to a string via `Display`, matching common-sql's
+/// precision-preserving `Float(String)` shape. Precision beyond `f64` is
+/// already lost in `CommonLiteral`, so this is the best the bridge can do.
+impl From<CommonLiteral> for SqlLiteral {
+    fn from(lit: CommonLiteral) -> Self {
+        match lit {
+            CommonLiteral::String(s) => SqlLiteral::String(s),
+            CommonLiteral::Integer(i) => SqlLiteral::Integer(i),
+            CommonLiteral::Float(f) => SqlLiteral::Float(f.to_string()),
+            CommonLiteral::Null => SqlLiteral::Null,
+            CommonLiteral::Boolean(b) => SqlLiteral::Boolean(b),
+        }
+    }
+}
+
+/// Convert a legacy [`CommonIdentifier`] into the standalone
+/// [`common_sql::ast::Identifier`] (unquoted).
+impl From<CommonIdentifier> for SqlIdentifier {
+    fn from(id: CommonIdentifier) -> Self {
+        SqlIdentifier::new(id.name)
+    }
+}
+
+/// Convert a legacy [`CommonUnaryOperator`] into the standalone
+/// [`common_sql::ast::UnaryOperator`].
+impl From<CommonUnaryOperator> for SqlUnaryOperator {
+    fn from(op: CommonUnaryOperator) -> Self {
+        match op {
+            CommonUnaryOperator::Plus => SqlUnaryOperator::Plus,
+            CommonUnaryOperator::Minus => SqlUnaryOperator::Minus,
+            CommonUnaryOperator::Not => SqlUnaryOperator::Not,
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 #[allow(clippy::panic)]
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+
+    // -- leaf conversions: Literal / Identifier / UnaryOperator ------------
+
+    #[test]
+    fn literal_maps_identity_except_float() {
+        assert_eq!(
+            SqlLiteral::from(CommonLiteral::String("hi".to_string())),
+            SqlLiteral::String("hi".to_string())
+        );
+        assert_eq!(
+            SqlLiteral::from(CommonLiteral::Integer(7)),
+            SqlLiteral::Integer(7)
+        );
+        assert_eq!(SqlLiteral::from(CommonLiteral::Null), SqlLiteral::Null);
+        assert_eq!(
+            SqlLiteral::from(CommonLiteral::Boolean(true)),
+            SqlLiteral::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn literal_float_renders_to_string() {
+        let got: SqlLiteral = CommonLiteral::Float(1.5_f64).into();
+        assert_eq!(got, SqlLiteral::Float("1.5".to_string()));
+    }
+
+    #[test]
+    fn identifier_preserves_name() {
+        let id = SqlIdentifier::from(CommonIdentifier {
+            name: "count".to_string(),
+        });
+        assert_eq!(id.value(), "count");
+        assert!(!id.quoted());
+    }
+
+    #[test]
+    fn unary_operator_maps_identity() {
+        assert_eq!(
+            SqlUnaryOperator::from(CommonUnaryOperator::Plus),
+            SqlUnaryOperator::Plus
+        );
+        assert_eq!(
+            SqlUnaryOperator::from(CommonUnaryOperator::Minus),
+            SqlUnaryOperator::Minus
+        );
+        assert_eq!(
+            SqlUnaryOperator::from(CommonUnaryOperator::Not),
+            SqlUnaryOperator::Not
+        );
+    }
 
     // -- identity mappings --------------------------------------------------
 

--- a/crates/tsql-parser/src/common/convert_common_sql.rs
+++ b/crates/tsql-parser/src/common/convert_common_sql.rs
@@ -10,11 +10,24 @@
 //! discarded, which is range-safe for typical values.
 
 use common_sql::ast::{
-    DataType as SqlDataType, Identifier as SqlIdentifier, Literal as SqlLiteral,
-    UnaryOperator as SqlUnaryOperator,
+    Assignment as SqlAssignment, BinaryOperator as SqlBinaryOperator,
+    ComparisonOperator as SqlComparisonOperator, DataType as SqlDataType,
+    DeleteStatement as SqlDeleteStatement, Expression as SqlExpression,
+    Identifier as SqlIdentifier, InList as SqlInList, InsertSource as SqlInsertSource,
+    InsertStatement as SqlInsertStatement, LimitClause as SqlLimitClause, Literal as SqlLiteral,
+    LogicalOperator as SqlLogicalOperator, OrderByItem as SqlOrderByItem,
+    QualifiedName as SqlQualifiedName, SelectItem as SqlSelectItem,
+    SelectStatement as SqlSelectStatement, TableFactor as SqlTableFactor,
+    UnaryOperator as SqlUnaryOperator, UpdateStatement as SqlUpdateStatement,
 };
 
-use crate::common::{CommonDataType, CommonIdentifier, CommonLiteral, CommonUnaryOperator};
+use crate::common::{
+    CommonAssignment, CommonBinaryOperator, CommonCaseExpression, CommonColumnReference,
+    CommonDataType, CommonDeleteStatement, CommonExpression, CommonFunctionCall, CommonIdentifier,
+    CommonInList, CommonInsertSource, CommonInsertStatement, CommonLimitClause, CommonLiteral,
+    CommonOrderByItem, CommonSelectItem, CommonSelectStatement, CommonStatement,
+    CommonTableReference, CommonUnaryOperator, CommonUpdateStatement,
+};
 
 /// Convert a legacy [`CommonDataType`] into the standalone
 /// [`common_sql::ast::DataType`].
@@ -94,6 +107,614 @@ impl From<CommonUnaryOperator> for SqlUnaryOperator {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Expression bridge (T3): recursive 13-variant conversion.
+// ---------------------------------------------------------------------------
+
+/// Dispatch a legacy binary operator + its two operands into the correct
+/// `common_sql` `Expression` variant.
+///
+/// The legacy side models *all* binary operators with a single
+/// 14-variant [`CommonBinaryOperator`] enum. The destination splits these
+/// across three enums living in three different `Expression` variants
+/// (`BinaryOp` / `Comparison` / `LogicalOp`). A plain `From` on the operator
+/// alone cannot select the wrapping `Expression` variant, so this helper
+/// inspects the operator and emits the correct node shape.
+///
+/// The match is exhaustive over `CommonBinaryOperator`: adding a new legacy
+/// variant forces this bridge to be updated in lockstep.
+///
+/// Spans are silently dropped (the destination `Expression` carries none).
+#[must_use]
+fn convert_binary_op(
+    left: CommonExpression,
+    op: CommonBinaryOperator,
+    right: CommonExpression,
+) -> SqlExpression {
+    let left = Box::new(SqlExpression::from(left));
+    let right = Box::new(SqlExpression::from(right));
+    match op {
+        // Arithmetic -> Expression::BinaryOp
+        CommonBinaryOperator::Plus => SqlExpression::BinaryOp {
+            left,
+            op: SqlBinaryOperator::Add,
+            right,
+        },
+        CommonBinaryOperator::Minus => SqlExpression::BinaryOp {
+            left,
+            op: SqlBinaryOperator::Sub,
+            right,
+        },
+        CommonBinaryOperator::Multiply => SqlExpression::BinaryOp {
+            left,
+            op: SqlBinaryOperator::Mul,
+            right,
+        },
+        CommonBinaryOperator::Divide => SqlExpression::BinaryOp {
+            left,
+            op: SqlBinaryOperator::Div,
+            right,
+        },
+        CommonBinaryOperator::Modulo => SqlExpression::BinaryOp {
+            left,
+            op: SqlBinaryOperator::Mod,
+            right,
+        },
+        CommonBinaryOperator::Concat => SqlExpression::BinaryOp {
+            left,
+            op: SqlBinaryOperator::Concat,
+            right,
+        },
+        // Comparison -> Expression::Comparison
+        CommonBinaryOperator::Eq => SqlExpression::Comparison {
+            left,
+            op: SqlComparisonOperator::Eq,
+            right,
+        },
+        CommonBinaryOperator::Ne => SqlExpression::Comparison {
+            left,
+            op: SqlComparisonOperator::Ne,
+            right,
+        },
+        CommonBinaryOperator::Lt => SqlExpression::Comparison {
+            left,
+            op: SqlComparisonOperator::Lt,
+            right,
+        },
+        CommonBinaryOperator::Le => SqlExpression::Comparison {
+            left,
+            op: SqlComparisonOperator::Le,
+            right,
+        },
+        CommonBinaryOperator::Gt => SqlExpression::Comparison {
+            left,
+            op: SqlComparisonOperator::Gt,
+            right,
+        },
+        CommonBinaryOperator::Ge => SqlExpression::Comparison {
+            left,
+            op: SqlComparisonOperator::Ge,
+            right,
+        },
+        // Logical -> Expression::LogicalOp
+        CommonBinaryOperator::And => SqlExpression::LogicalOp {
+            left,
+            op: SqlLogicalOperator::And,
+            right,
+        },
+        CommonBinaryOperator::Or => SqlExpression::LogicalOp {
+            left,
+            op: SqlLogicalOperator::Or,
+            right,
+        },
+    }
+}
+
+/// Convert a legacy [`CommonColumnReference`] into the destination expression
+/// shape: a qualifier produces `QualifiedIdentifier`, otherwise a bare
+/// `Identifier`.
+impl From<CommonColumnReference> for SqlExpression {
+    fn from(col: CommonColumnReference) -> Self {
+        match col.table {
+            Some(table) => SqlExpression::QualifiedIdentifier {
+                table: SqlIdentifier::new(table),
+                column: SqlIdentifier::new(col.column),
+            },
+            None => SqlExpression::Identifier(SqlIdentifier::new(col.column)),
+        }
+    }
+}
+
+/// Convert a legacy [`CommonFunctionCall`] into a destination `Function` node.
+///
+/// The legacy `name: String` becomes a `common_sql` `Identifier`; `args`
+/// recurse through [`From<CommonExpression>`]; `distinct` passes through.
+impl From<CommonFunctionCall> for SqlExpression {
+    fn from(call: CommonFunctionCall) -> Self {
+        SqlExpression::Function {
+            name: SqlIdentifier::new(call.name),
+            args: call.args.into_iter().map(SqlExpression::from).collect(),
+            distinct: call.distinct,
+        }
+    }
+}
+
+/// Convert a legacy [`CommonCaseExpression`] into a destination `Case` node.
+///
+/// Lossy design decision (recorded): the legacy CASE is searched-CASE only —
+/// there is no simple-CASE operand on the source side, so the destination
+/// `operand` field is always `None`. The source `branches` field is renamed to
+/// `conditions`. `else_result` recurses.
+impl From<CommonCaseExpression> for SqlExpression {
+    fn from(case: CommonCaseExpression) -> Self {
+        SqlExpression::Case {
+            operand: None,
+            conditions: case
+                .branches
+                .into_iter()
+                .map(|(when, then)| (SqlExpression::from(when), SqlExpression::from(then)))
+                .collect(),
+            else_result: case.else_result.map(|e| Box::new(SqlExpression::from(*e))),
+        }
+    }
+}
+
+/// Convert a legacy [`CommonInList`] into the destination [`SqlInList`].
+///
+/// `Values` recurses element-wise; `Subquery` converts the inner select.
+impl From<CommonInList> for SqlInList {
+    fn from(list: CommonInList) -> Self {
+        match list {
+            CommonInList::Values(exprs) => {
+                SqlInList::Values(exprs.into_iter().map(SqlExpression::from).collect())
+            }
+            CommonInList::Subquery(query) => {
+                SqlInList::Subquery(Box::new(SqlSelectStatement::from(*query)))
+            }
+        }
+    }
+}
+
+/// Convert a legacy [`CommonExpression`] into the standalone
+/// `common_sql::ast::Expression`.
+///
+/// # Lossy mappings (recorded)
+///
+/// * **Span** is dropped on *every* variant — the destination `Expression`
+///   has no span field. Any downstream assertion on offset/line info will not
+///   round-trip.
+/// * **`Like`** is folded into `Expression::Comparison` with operator
+///   `ComparisonOperator::Like` / `NotLike`. The optional `ESCAPE` clause is
+///   silently dropped (there is no place for it on the destination). The
+///   destination's `ILike` / `NotILike` variants are **never** produced by
+///   this bridge — the legacy side has no case-insensitive LIKE.
+/// * **`Case`** always sets `operand = None` (see
+///   [`From<CommonCaseExpression>`]).
+/// * **`Subquery` / `Exists`** rename the source `query` field to the
+///   destination `subquery` field.
+///
+/// # Destination variants never produced
+///
+/// The bridge is one-directional (legacy -> common_sql). The destination
+/// `Expression` has variants with no legacy source and which are therefore
+/// never emitted here: `Cast` (legacy has no CAST), and the `ILike` /
+/// `NotILike` comparison operators. The exhaustiveness guard relies on
+/// `match` compile-fail, which catches *new* legacy variants only — not
+/// unmapped destination variants.
+impl From<CommonExpression> for SqlExpression {
+    fn from(expr: CommonExpression) -> Self {
+        match expr {
+            // Leaves (existing From impls).
+            CommonExpression::Literal(lit) => SqlExpression::Literal(SqlLiteral::from(lit)),
+            CommonExpression::Identifier(id) => SqlExpression::Identifier(SqlIdentifier::from(id)),
+            // ColumnReference -> QualifiedIdentifier | Identifier.
+            CommonExpression::ColumnReference(col) => SqlExpression::from(col),
+            // UnaryOp reuses the leaf operator From.
+            CommonExpression::UnaryOp { op, expr, .. } => SqlExpression::UnaryOp {
+                op: SqlUnaryOperator::from(op),
+                expr: Box::new(SqlExpression::from(*expr)),
+            },
+            // BinaryOp dispatches across the three destination variants.
+            CommonExpression::BinaryOp {
+                left, op, right, ..
+            } => convert_binary_op(*left, op, *right),
+            // FunctionCall (name String -> Identifier).
+            CommonExpression::FunctionCall(call) => SqlExpression::from(call),
+            // CASE: operand=None always.
+            CommonExpression::Case(case) => SqlExpression::from(case),
+            // IN: negated passes through, list recurses.
+            CommonExpression::In {
+                expr,
+                list,
+                negated,
+                ..
+            } => SqlExpression::In {
+                expr: Box::new(SqlExpression::from(*expr)),
+                list: SqlInList::from(list),
+                negated,
+            },
+            // BETWEEN: bounds recurse, negated passes through.
+            CommonExpression::Between {
+                expr,
+                low,
+                high,
+                negated,
+                ..
+            } => SqlExpression::Between {
+                expr: Box::new(SqlExpression::from(*expr)),
+                low: Box::new(SqlExpression::from(*low)),
+                high: Box::new(SqlExpression::from(*high)),
+                negated,
+            },
+            // LIKE -> Comparison::{Like,NotLike}; ESCAPE dropped.
+            CommonExpression::Like {
+                expr,
+                pattern,
+                escape: _,
+                negated,
+                ..
+            } => SqlExpression::Comparison {
+                left: Box::new(SqlExpression::from(*expr)),
+                op: if negated {
+                    SqlComparisonOperator::NotLike
+                } else {
+                    SqlComparisonOperator::Like
+                },
+                right: Box::new(SqlExpression::from(*pattern)),
+            },
+            // IS NULL: negated passes through.
+            CommonExpression::IsNull { expr, negated, .. } => SqlExpression::IsNull {
+                expr: Box::new(SqlExpression::from(*expr)),
+                negated,
+            },
+            // Subquery: query field -> subquery field rename.
+            CommonExpression::Subquery { query, .. } => {
+                SqlExpression::Subquery(Box::new(SqlSelectStatement::from(*query)))
+            }
+            // Exists: query field -> subquery field rename, negated passes through.
+            CommonExpression::Exists { query, negated, .. } => SqlExpression::Exists {
+                subquery: Box::new(SqlSelectStatement::from(*query)),
+                negated,
+            },
+        }
+    }
+}
+
+/// Convert a legacy [`CommonTableReference`] into a destination
+/// [`SqlTableFactor`].
+///
+/// * `Table { name, alias }` — the bare `String` name becomes a
+///   [`SqlQualifiedName`] with no schema; the optional `String` alias becomes
+///   a [`common_sql::ast::TableAlias`] with no column aliases.
+/// * `Derived { subquery, alias }` — the subquery recurses through
+///   [`From<CommonSelectStatement>`]; alias mapping is the same as `Table`.
+///
+/// Span is dropped (the destination `TableFactor` carries none).
+impl From<CommonTableReference> for SqlTableFactor {
+    fn from(ref_: CommonTableReference) -> Self {
+        match ref_ {
+            CommonTableReference::Table { name, alias, .. } => SqlTableFactor::Table {
+                name: qualified_name_from_string(name),
+                alias: alias.map(|a| common_sql::ast::TableAlias::new(a, vec![])),
+            },
+            CommonTableReference::Derived {
+                subquery, alias, ..
+            } => SqlTableFactor::Derived {
+                subquery: Box::new(SqlSelectStatement::from(*subquery)),
+                alias: alias.map(|a| common_sql::ast::TableAlias::new(a, vec![])),
+            },
+        }
+    }
+}
+
+/// Collapse a legacy `Vec<CommonTableReference>` into the destination's
+/// `Option<TableFactor>`.
+///
+/// # Lossy mapping (recorded)
+///
+/// The legacy FROM clause is a `Vec<CommonTableReference>` (comma-separated
+/// tables in T-SQL), but the destination models FROM as a single
+/// `Option<TableFactor>` (multi-table FROM is expressed via `Join` nodes). We
+/// cannot safely flatten N>1 table references into one `TableFactor`:
+///
+/// * A `CROSS JOIN` would change semantics and is not what the legacy comma
+///   list necessarily means, and
+/// * no join condition can be synthesized from the legacy node (it carries
+///   none).
+///
+/// Therefore the **first** element is taken and any additional elements are
+/// **silently dropped**. This is lossy for multi-table FROM; the accepted
+/// trade-off is documented here. An empty `Vec` yields `None`.
+fn collapse_from(from: Vec<CommonTableReference>) -> Option<SqlTableFactor> {
+    let mut iter = from.into_iter();
+    iter.next().map(SqlTableFactor::from)
+}
+
+/// Convert a legacy [`CommonSelectStatement`] into the destination
+/// [`SqlSelectStatement`].
+///
+/// This is the full T4 conversion (projection / FROM / WHERE / GROUP BY /
+/// HAVING / ORDER BY / LIMIT). `WITH` (CTE) is always `None` — the legacy
+/// node carries no CTE clause. Span is dropped.
+///
+/// # Lossy mapping (recorded)
+///
+/// `from: Vec<CommonTableReference>` is collapsed via [`collapse_from`] —
+/// only the first table reference survives. See that function's docs.
+/// Convert a legacy [`CommonSelectItem`] into the destination
+/// [`SqlSelectItem`].
+///
+/// Span is not carried (destination variants hold none).
+impl From<CommonSelectItem> for SqlSelectItem {
+    fn from(item: CommonSelectItem) -> Self {
+        match item {
+            CommonSelectItem::Wildcard => SqlSelectItem::Wildcard,
+            CommonSelectItem::QualifiedWildcard(table) => SqlSelectItem::QualifiedWildcard {
+                table: SqlIdentifier::new(table),
+            },
+            CommonSelectItem::Expression(expr, alias) => SqlSelectItem::Expression {
+                expr: SqlExpression::from(expr),
+                alias: alias.map(SqlIdentifier::new),
+            },
+        }
+    }
+}
+
+/// Convert a legacy [`CommonOrderByItem`] into the destination
+/// [`SqlOrderByItem`].
+///
+/// `asc: bool` maps to an explicit
+/// [`SortDirection`](common_sql::ast::SortDirection); the legacy node carries
+/// no NULLS ordering, so `nulls` is `None`.
+impl From<CommonOrderByItem> for SqlOrderByItem {
+    fn from(item: CommonOrderByItem) -> Self {
+        SqlOrderByItem {
+            expr: SqlExpression::from(item.expr),
+            direction: Some(if item.asc {
+                common_sql::ast::SortDirection::Asc
+            } else {
+                common_sql::ast::SortDirection::Desc
+            }),
+            // Legacy carries no NULLS ordering -> None (DB default).
+            nulls: None,
+        }
+    }
+}
+
+/// Convert a legacy [`CommonLimitClause`] into the destination
+/// [`SqlLimitClause`].
+///
+/// Span is dropped (destination uses a zero placeholder).
+impl From<CommonLimitClause> for SqlLimitClause {
+    fn from(l: CommonLimitClause) -> Self {
+        SqlLimitClause {
+            span: common_sql::ast::Span::new(0, 0),
+            limit: SqlExpression::from(l.limit),
+            offset: l.offset.map(SqlExpression::from),
+        }
+    }
+}
+
+impl From<CommonSelectStatement> for SqlSelectStatement {
+    fn from(sel: CommonSelectStatement) -> Self {
+        use common_sql::ast::{GroupByClause, GroupByItem, OrderByClause};
+
+        SqlSelectStatement {
+            // Span dropped (destination field required but unused here).
+            span: common_sql::ast::Span::new(0, 0),
+            // Legacy has no WITH (CTE) -> always None.
+            with: None,
+            projection: sel.columns.into_iter().map(SqlSelectItem::from).collect(),
+            from: collapse_from(sel.from),
+            where_clause: sel.where_clause.map(SqlExpression::from),
+            group_by: if sel.group_by.is_empty() {
+                None
+            } else {
+                Some(GroupByClause {
+                    span: common_sql::ast::Span::new(0, 0),
+                    items: sel
+                        .group_by
+                        .into_iter()
+                        .map(SqlExpression::from)
+                        .map(GroupByItem::Expression)
+                        .collect(),
+                })
+            },
+            having: sel.having.map(SqlExpression::from),
+            order_by: if sel.order_by.is_empty() {
+                None
+            } else {
+                Some(OrderByClause {
+                    span: common_sql::ast::Span::new(0, 0),
+                    items: sel.order_by.into_iter().map(SqlOrderByItem::from).collect(),
+                })
+            },
+            limit: sel.limit.map(SqlLimitClause::from),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Statement bridge (T6): CommonStatement -> Option<common_sql::ast::Statement>.
+// ---------------------------------------------------------------------------
+
+/// Convert a legacy [`CommonStatement`] into the standalone
+/// `common_sql::ast::Statement`.
+///
+/// This is the **entry point** of the `tsql_parser -> common_sql` statement
+/// bridge. It is a free function returning `Option<Statement>` — **not** a
+/// plain `From<CommonStatement>` — because
+/// [`CommonStatement::DialectSpecific`] has no equivalent variant on the
+/// destination [`Statement`] enum, and the bridge therefore drops it
+/// (returning `None`). This mirrors the source-side
+/// [`ToCommonAst::to_common_ast`](crate::common::ToCommonAst::to_common_ast)
+/// -> `Option<CommonStatement>`, which itself returns `None` for constructs it
+/// cannot represent.
+///
+/// `Select` / `Insert` / `Update` / `Delete` each map to the corresponding
+/// boxed destination variant (`Statement::Select(Box<_>)`, etc.).
+///
+/// # Lossy mapping (recorded)
+///
+/// * **`DialectSpecific`** -> `None` (dropped; no destination variant).
+/// * **Span** is dropped for every statement (destination spans are set to a
+///   zero placeholder; the legacy span does not round-trip).
+///
+/// # Destination variants never produced
+///
+/// The bridge is one-directional (legacy -> common_sql). The destination
+/// `Statement` has variants with no legacy source: `CreateTable`, `AlterTable`,
+/// `DropTable`, `CreateIndex`, `DropIndex`. These are never emitted by this
+/// function. The exhaustiveness guard relies on `match` compile-fail, which
+/// catches *new* legacy variants only — not unmapped destination variants.
+#[must_use]
+pub fn convert(stmt: CommonStatement) -> Option<common_sql::ast::Statement> {
+    use common_sql::ast::Statement as SqlStatement;
+    match stmt {
+        CommonStatement::Select(sel) => Some(SqlStatement::Select(Box::new(
+            SqlSelectStatement::from(sel),
+        ))),
+        CommonStatement::Insert(ins) => Some(SqlStatement::Insert(Box::new(
+            SqlInsertStatement::from(ins),
+        ))),
+        CommonStatement::Update(upd) => Some(SqlStatement::Update(Box::new(
+            SqlUpdateStatement::from(upd),
+        ))),
+        CommonStatement::Delete(del) => Some(SqlStatement::Delete(Box::new(
+            SqlDeleteStatement::from(del),
+        ))),
+        // No destination variant for dialect-specific statements -> drop.
+        CommonStatement::DialectSpecific { .. } => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DML bridge (T5): INSERT / UPDATE / DELETE / Assignment.
+// ---------------------------------------------------------------------------
+
+/// Convert a legacy `String` table name into a destination [`SqlQualifiedName`]
+/// with no schema qualifier.
+fn qualified_name_from_string(name: String) -> SqlQualifiedName {
+    SqlQualifiedName::new(None, name)
+}
+
+/// Convert a legacy `String` table name into a destination bare-table
+/// [`SqlTableFactor`] (no alias).
+fn table_factor_from_string(name: String) -> SqlTableFactor {
+    SqlTableFactor::Table {
+        name: qualified_name_from_string(name),
+        alias: None,
+    }
+}
+
+/// Convert a legacy [`CommonAssignment`] into a destination
+/// [`SqlAssignment`].
+///
+/// The legacy `column: String` becomes a `common_sql` `Identifier`; the
+/// `value` recurses through [`From<CommonExpression>`].
+impl From<CommonAssignment> for SqlAssignment {
+    fn from(a: CommonAssignment) -> Self {
+        SqlAssignment {
+            column: SqlIdentifier::new(a.column),
+            value: SqlExpression::from(a.value),
+        }
+    }
+}
+
+/// Convert a legacy [`CommonInsertSource`] into a destination
+/// [`SqlInsertSource`].
+///
+/// # Lossy mapping (recorded)
+///
+/// `CommonInsertSource::DefaultValues` has no counterpart on the destination
+/// `InsertSource` (there is no `DefaultValues` variant). It is mapped to
+/// `InsertSource::Values(vec![])` — an empty `VALUES` list. This is lossy: the
+/// destination can no longer distinguish `INSERT ... DEFAULT VALUES` from
+/// `INSERT ... VALUES ()`. `Values` and `Select` recurse normally.
+impl From<CommonInsertSource> for SqlInsertSource {
+    fn from(src: CommonInsertSource) -> Self {
+        match src {
+            CommonInsertSource::Values(rows) => SqlInsertSource::Values(
+                rows.into_iter()
+                    .map(|row| row.into_iter().map(SqlExpression::from).collect())
+                    .collect(),
+            ),
+            CommonInsertSource::Select(query) => {
+                SqlInsertSource::Select(Box::new(SqlSelectStatement::from(*query)))
+            }
+            // Lossy: destination has no DefaultValues variant -> empty Values.
+            CommonInsertSource::DefaultValues => SqlInsertSource::Values(vec![]),
+        }
+    }
+}
+
+/// Convert a legacy [`CommonInsertStatement`] into a destination
+/// [`SqlInsertStatement`].
+///
+/// Impedance resolved:
+/// * `table: String` -> `QualifiedName::new(None, name)` (no schema).
+/// * `columns: Vec<String>` -> `Vec<Identifier>`.
+/// * `source` recurses through [`From<CommonInsertSource>`].
+/// * `on_conflict` is always `None` (the legacy node carries none).
+/// * Span is dropped.
+impl From<CommonInsertStatement> for SqlInsertStatement {
+    fn from(ins: CommonInsertStatement) -> Self {
+        SqlInsertStatement {
+            // Span dropped (destination field required but unused here).
+            span: common_sql::ast::Span::new(0, 0),
+            table: qualified_name_from_string(ins.table),
+            columns: ins.columns.into_iter().map(SqlIdentifier::new).collect(),
+            source: SqlInsertSource::from(ins.source),
+            on_conflict: None,
+        }
+    }
+}
+
+/// Convert a legacy [`CommonUpdateStatement`] into a destination
+/// [`SqlUpdateStatement`].
+///
+/// Impedance resolved:
+/// * `table: String` -> `TableFactor::Table { name, alias: None }` (the
+///   destination `table` field expects a `TableFactor`).
+/// * `assignments: Vec<CommonAssignment>` -> `Vec<Assignment>`.
+/// * `from` -> `None` (the legacy node has no FROM clause).
+/// * `where_clause` recurses through [`From<CommonExpression>`].
+/// * Span is dropped.
+impl From<CommonUpdateStatement> for SqlUpdateStatement {
+    fn from(upd: CommonUpdateStatement) -> Self {
+        SqlUpdateStatement {
+            span: common_sql::ast::Span::new(0, 0),
+            table: table_factor_from_string(upd.table),
+            assignments: upd
+                .assignments
+                .into_iter()
+                .map(SqlAssignment::from)
+                .collect(),
+            from: None,
+            where_clause: upd.where_clause.map(SqlExpression::from),
+        }
+    }
+}
+
+/// Convert a legacy [`CommonDeleteStatement`] into a destination
+/// [`SqlDeleteStatement`].
+///
+/// Impedance resolved:
+/// * `table: String` -> `TableFactor::Table { name, alias: None }`.
+/// * `using` -> `None` (the legacy node has no USING clause).
+/// * `where_clause` recurses through [`From<CommonExpression>`].
+/// * Span is dropped.
+impl From<CommonDeleteStatement> for SqlDeleteStatement {
+    fn from(del: CommonDeleteStatement) -> Self {
+        SqlDeleteStatement {
+            span: common_sql::ast::Span::new(0, 0),
+            table: table_factor_from_string(del.table),
+            using: None,
+            where_clause: del.where_clause.map(SqlExpression::from),
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 #[allow(clippy::panic)]
@@ -149,6 +770,131 @@ mod tests {
             SqlUnaryOperator::from(CommonUnaryOperator::Not),
             SqlUnaryOperator::Not
         );
+    }
+
+    // -- operator-split dispatch (Task #36 / T2) ----------------------------
+    //
+    // The legacy `CommonBinaryOperator` is a single 14-variant enum that must
+    // dispatch into THREE destination Expression variants depending on the
+    // operator class:
+    //   * arithmetic + concat  -> Expression::BinaryOp  (BinaryOperator)
+    //   * comparison           -> Expression::Comparison (ComparisonOperator)
+    //   * logical              -> Expression::LogicalOp  (LogicalOperator)
+    //
+    // A plain `From<CommonBinaryOperator>` cannot choose the wrapping variant,
+    // so the bridge exposes `convert_binary_op(left, op, right) -> Expression`.
+
+    /// Build a trivial leaf expression for test inputs.
+    fn leaf(s: &str) -> CommonExpression {
+        CommonExpression::Identifier(CommonIdentifier {
+            name: s.to_string(),
+        })
+    }
+
+    #[test]
+    fn arithmetic_operators_dispatch_to_binary_op() {
+        for (legacy_op, sql_op) in [
+            (CommonBinaryOperator::Plus, SqlBinaryOperator::Add),
+            (CommonBinaryOperator::Minus, SqlBinaryOperator::Sub),
+            (CommonBinaryOperator::Multiply, SqlBinaryOperator::Mul),
+            (CommonBinaryOperator::Divide, SqlBinaryOperator::Div),
+            (CommonBinaryOperator::Modulo, SqlBinaryOperator::Mod),
+            (CommonBinaryOperator::Concat, SqlBinaryOperator::Concat),
+        ] {
+            let got = convert_binary_op(leaf("a"), legacy_op, leaf("b"));
+            match got {
+                SqlExpression::BinaryOp { op, .. } => assert_eq!(op, sql_op),
+                other => panic!("expected BinaryOp for {legacy_op:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn comparison_operators_dispatch_to_comparison() {
+        for (legacy_op, sql_op) in [
+            (CommonBinaryOperator::Eq, SqlComparisonOperator::Eq),
+            (CommonBinaryOperator::Ne, SqlComparisonOperator::Ne),
+            (CommonBinaryOperator::Lt, SqlComparisonOperator::Lt),
+            (CommonBinaryOperator::Le, SqlComparisonOperator::Le),
+            (CommonBinaryOperator::Gt, SqlComparisonOperator::Gt),
+            (CommonBinaryOperator::Ge, SqlComparisonOperator::Ge),
+        ] {
+            let got = convert_binary_op(leaf("a"), legacy_op, leaf("b"));
+            match got {
+                SqlExpression::Comparison { op, .. } => assert_eq!(op, sql_op),
+                other => panic!("expected Comparison for {legacy_op:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn logical_operators_dispatch_to_logical_op() {
+        for (legacy_op, sql_op) in [
+            (CommonBinaryOperator::And, SqlLogicalOperator::And),
+            (CommonBinaryOperator::Or, SqlLogicalOperator::Or),
+        ] {
+            let got = convert_binary_op(leaf("a"), legacy_op, leaf("b"));
+            match got {
+                SqlExpression::LogicalOp { op, .. } => assert_eq!(op, sql_op),
+                other => panic!("expected LogicalOp for {legacy_op:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn binary_dispatch_preserves_recursed_operands() {
+        // (a + b) > c — the helper converts each operand via From, so a nested
+        // legacy BinaryOp operand recurses into the correct destination shape.
+        let inner = CommonExpression::BinaryOp {
+            left: Box::new(leaf("a")),
+            op: CommonBinaryOperator::Plus,
+            right: Box::new(leaf("b")),
+            span: tsql_token::Span::new(0, 0),
+        };
+        let outer_sql = convert_binary_op(inner, CommonBinaryOperator::Gt, leaf("c"));
+
+        match outer_sql {
+            SqlExpression::Comparison { op, left, right } => {
+                assert_eq!(op, SqlComparisonOperator::Gt);
+                // The left operand should have recursed into a BinaryOp.
+                assert!(matches!(*left, SqlExpression::BinaryOp { .. }));
+                assert!(matches!(*right, SqlExpression::Identifier(_)));
+            }
+            other => panic!("expected Comparison, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_fourteen_legacy_operators_are_covered_by_dispatch() {
+        // Exhaustiveness guard: if a new variant is added to CommonBinaryOperator,
+        // the dispatch `match` stops compiling. This test asserts the 14 known
+        // variants each land in the right destination class.
+        let all = [
+            CommonBinaryOperator::Plus,
+            CommonBinaryOperator::Minus,
+            CommonBinaryOperator::Multiply,
+            CommonBinaryOperator::Divide,
+            CommonBinaryOperator::Modulo,
+            CommonBinaryOperator::Concat,
+            CommonBinaryOperator::Eq,
+            CommonBinaryOperator::Ne,
+            CommonBinaryOperator::Lt,
+            CommonBinaryOperator::Le,
+            CommonBinaryOperator::Gt,
+            CommonBinaryOperator::Ge,
+            CommonBinaryOperator::And,
+            CommonBinaryOperator::Or,
+        ];
+        for op in all {
+            let got = convert_binary_op(leaf("x"), op, leaf("y"));
+            let class = match &got {
+                SqlExpression::BinaryOp { .. } => "binary",
+                SqlExpression::Comparison { .. } => "comparison",
+                SqlExpression::LogicalOp { .. } => "logical",
+                other => panic!("unexpected dispatch target {other:?} for {op:?}"),
+            };
+            assert!(!class.is_empty());
+        }
     }
 
     // -- identity mappings --------------------------------------------------

--- a/crates/tsql-parser/src/common/convert_common_sql.rs
+++ b/crates/tsql-parser/src/common/convert_common_sql.rs
@@ -1,0 +1,201 @@
+//! Bridge from the legacy internal `Common*` AST to the standalone
+//! `common_sql::ast` crate.
+//!
+//! This is the data-type slice of the `tsql_parser -> common_sql` conversion
+//! bridge — the T0 prerequisite for the mysql-emitter migration (#147). The
+//! `common-sql` crate was extracted from this module, so the two enums are
+//! near-identical. The single impedance is `CommonDataType::Float`, which has
+//! no exact `common_sql` counterpart (the crate models `REAL` and
+//! `DOUBLE PRECISION` only); it maps to `DoublePrecision` with its precision
+//! discarded, which is range-safe for typical values.
+
+use common_sql::ast::DataType as SqlDataType;
+
+use crate::common::CommonDataType;
+
+/// Convert a legacy [`CommonDataType`] into the standalone
+/// [`common_sql::ast::DataType`].
+///
+/// `Float` is the only lossy case (see the module docs).
+impl From<CommonDataType> for SqlDataType {
+    fn from(dt: CommonDataType) -> Self {
+        match dt {
+            CommonDataType::TinyInt => SqlDataType::TinyInt,
+            CommonDataType::SmallInt => SqlDataType::SmallInt,
+            CommonDataType::Int => SqlDataType::Int,
+            CommonDataType::BigInt => SqlDataType::BigInt,
+            CommonDataType::Decimal { precision, scale } => {
+                SqlDataType::Decimal { precision, scale }
+            }
+            CommonDataType::Numeric { precision, scale } => {
+                SqlDataType::Numeric { precision, scale }
+            }
+            CommonDataType::Real => SqlDataType::Real,
+            CommonDataType::DoublePrecision => SqlDataType::DoublePrecision,
+            // common-sql has no FLOAT variant; collapse to DOUBLE PRECISION.
+            CommonDataType::Float { .. } => SqlDataType::DoublePrecision,
+            CommonDataType::Char { length } => SqlDataType::Char { length },
+            CommonDataType::VarChar { length } => SqlDataType::VarChar { length },
+            CommonDataType::Text => SqlDataType::Text,
+            CommonDataType::NChar { length } => SqlDataType::NChar { length },
+            CommonDataType::NVarChar { length } => SqlDataType::NVarChar { length },
+            CommonDataType::Date => SqlDataType::Date,
+            CommonDataType::Time { precision } => SqlDataType::Time { precision },
+            CommonDataType::DateTime { precision } => SqlDataType::DateTime { precision },
+            CommonDataType::Timestamp { precision } => SqlDataType::Timestamp { precision },
+            CommonDataType::Binary { length } => SqlDataType::Binary { length },
+            CommonDataType::VarBinary { length } => SqlDataType::VarBinary { length },
+            CommonDataType::Blob => SqlDataType::Blob,
+            CommonDataType::Boolean => SqlDataType::Boolean,
+            CommonDataType::Uuid => SqlDataType::Uuid,
+            CommonDataType::Json => SqlDataType::Json,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // -- identity mappings --------------------------------------------------
+
+    #[test]
+    fn integer_types_map_identity() {
+        assert_eq!(
+            SqlDataType::from(CommonDataType::TinyInt),
+            SqlDataType::TinyInt
+        );
+        assert_eq!(
+            SqlDataType::from(CommonDataType::SmallInt),
+            SqlDataType::SmallInt
+        );
+        assert_eq!(SqlDataType::from(CommonDataType::Int), SqlDataType::Int);
+        assert_eq!(
+            SqlDataType::from(CommonDataType::BigInt),
+            SqlDataType::BigInt
+        );
+    }
+
+    #[test]
+    fn decimal_and_numeric_preserve_precision_and_scale() {
+        assert_eq!(
+            SqlDataType::from(CommonDataType::Decimal {
+                precision: Some(10),
+                scale: Some(2),
+            }),
+            SqlDataType::Decimal {
+                precision: Some(10),
+                scale: Some(2),
+            }
+        );
+        assert_eq!(
+            SqlDataType::from(CommonDataType::Numeric {
+                precision: None,
+                scale: None,
+            }),
+            SqlDataType::Numeric {
+                precision: None,
+                scale: None,
+            }
+        );
+    }
+
+    #[test]
+    fn floating_types_preserve_real_and_double() {
+        assert_eq!(SqlDataType::from(CommonDataType::Real), SqlDataType::Real);
+        assert_eq!(
+            SqlDataType::from(CommonDataType::DoublePrecision),
+            SqlDataType::DoublePrecision
+        );
+    }
+
+    #[test]
+    fn float_collapses_to_double_precision_discarding_precision() {
+        // common-sql has no FLOAT; the precision must be dropped.
+        assert_eq!(
+            SqlDataType::from(CommonDataType::Float {
+                precision: Some(24)
+            }),
+            SqlDataType::DoublePrecision
+        );
+    }
+
+    #[test]
+    fn character_types_preserve_length() {
+        assert_eq!(
+            SqlDataType::from(CommonDataType::Char { length: Some(10) }),
+            SqlDataType::Char { length: Some(10) }
+        );
+        assert_eq!(
+            SqlDataType::from(CommonDataType::VarChar { length: None }),
+            SqlDataType::VarChar { length: None }
+        );
+        assert_eq!(SqlDataType::from(CommonDataType::Text), SqlDataType::Text);
+    }
+
+    #[test]
+    fn national_character_types_preserve_length() {
+        assert_eq!(
+            SqlDataType::from(CommonDataType::NChar { length: Some(5) }),
+            SqlDataType::NChar { length: Some(5) }
+        );
+        assert_eq!(
+            SqlDataType::from(CommonDataType::NVarChar { length: Some(50) }),
+            SqlDataType::NVarChar { length: Some(50) }
+        );
+    }
+
+    #[test]
+    fn temporal_types_preserve_precision() {
+        assert_eq!(SqlDataType::from(CommonDataType::Date), SqlDataType::Date);
+        assert_eq!(
+            SqlDataType::from(CommonDataType::Time { precision: Some(3) }),
+            SqlDataType::Time { precision: Some(3) }
+        );
+        assert_eq!(
+            SqlDataType::from(CommonDataType::DateTime { precision: None }),
+            SqlDataType::DateTime { precision: None }
+        );
+        assert_eq!(
+            SqlDataType::from(CommonDataType::Timestamp { precision: Some(6) }),
+            SqlDataType::Timestamp { precision: Some(6) }
+        );
+    }
+
+    #[test]
+    fn binary_types_preserve_length() {
+        assert_eq!(
+            SqlDataType::from(CommonDataType::Binary { length: Some(16) }),
+            SqlDataType::Binary { length: Some(16) }
+        );
+        assert_eq!(
+            SqlDataType::from(CommonDataType::VarBinary { length: Some(255) }),
+            SqlDataType::VarBinary { length: Some(255) }
+        );
+        assert_eq!(SqlDataType::from(CommonDataType::Blob), SqlDataType::Blob);
+    }
+
+    #[test]
+    fn misc_types_map_identity() {
+        assert_eq!(
+            SqlDataType::from(CommonDataType::Boolean),
+            SqlDataType::Boolean
+        );
+        assert_eq!(SqlDataType::from(CommonDataType::Uuid), SqlDataType::Uuid);
+        assert_eq!(SqlDataType::from(CommonDataType::Json), SqlDataType::Json);
+    }
+
+    // -- exhaustiveness guard ----------------------------------------------
+    // Every CommonDataType variant is exercised above; if a variant is added
+    // to CommonDataType, the `match` in `From` stops compiling, forcing this
+    // bridge to be updated in lockstep.
+
+    #[test]
+    fn into_works_via_from_impl() {
+        let sql: SqlDataType = CommonDataType::Int.into();
+        assert_eq!(sql, SqlDataType::Int);
+    }
+}

--- a/crates/tsql-parser/src/common/mod.rs
+++ b/crates/tsql-parser/src/common/mod.rs
@@ -19,6 +19,8 @@ pub use statement::{
     CommonTableReference, CommonUpdateStatement,
 };
 
+pub use convert_common_sql::convert;
+
 /// Common SQL AST 変換トレイト
 ///
 /// T-SQL ASTノードを方言非依存の Common SQL AST に変換する。

--- a/crates/tsql-parser/src/common/mod.rs
+++ b/crates/tsql-parser/src/common/mod.rs
@@ -3,6 +3,7 @@
 //! 方言非依存のSQL抽象構文木（AST）を定義する。
 //! T-SQL 固有の構文から方言に依存しない表現への変換を目的とする。
 
+mod convert_common_sql;
 mod data_type;
 mod expression;
 mod statement;

--- a/crates/tsql-parser/tests/convert_common_sql_bridge.rs
+++ b/crates/tsql-parser/tests/convert_common_sql_bridge.rs
@@ -1,0 +1,474 @@
+//! T1 RED PHASE (Task #35 / issue #148) — `Common* -> common_sql::ast` bridge.
+//!
+//! These integration tests exercise the **composite** half of the conversion
+//! bridge that lives in `crates/tsql-parser/src/common/convert_common_sql.rs`:
+//! the statement-level nodes and the `convert()` entry point. They are the
+//! red-phase counterparts to the green-phase work tracked in tasks #36 / #40
+//! / #44.
+//!
+//! The leaf conversions (Literal / Identifier / UnaryOperator / DataType) and
+//! the T2 operator-dispatch + T3 expression bridge are covered by the inline
+//! unit tests in `convert_common_sql.rs` and are NOT duplicated here. This
+//! file targets the nodes the green phase has NOT yet wired:
+//!
+//!   * `convert(stmt: CommonStatement) -> Option<Statement>` entry point
+//!     (design decision (a): `DialectSpecific -> None`, so a free fn, not a
+//!     plain `From<CommonStatement>`)
+//!   * `From<CommonStatement>`-equivalent dispatch for Select/Insert/Update/
+//!     Delete/DialectSpecific
+//!   * `From<CommonSelectStatement>` full mapping (projection, FROM-as-first-
+//!     element, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT)
+//!   * `From<CommonTableReference>` (Table / Derived)
+//!   * `From<CommonInsertStatement>` + `CommonInsertSource` (design decision
+//!     (e): `DefaultValues -> InsertSource::Values(vec![])`)
+//!   * `From<CommonUpdateStatement>`, `From<CommonDeleteStatement>`
+//!   * `From<CommonAssignment>`, `From<CommonSelectItem>`,
+//!     `From<CommonOrderByItem>`, `From<CommonLimitClause>`
+//!
+//! ## Pinned design decisions (from the estimate approval)
+//!
+//!   (a) `DialectSpecific` has no destination variant -> `convert()` returns
+//!       `None`. The entry point is a free fn (or `TryFrom`), NOT a plain
+//!       `From<CommonStatement>`.
+//!   (b) `Vec<CommonTableReference>` (legacy FROM) -> `Option<TableFactor>`:
+//!       take the first element; extras are dropped (documented lossy).
+//!   (c) `LIKE` -> `ComparisonOperator::{Like, NotLike}`; the ESCAPE clause
+//!       is silently dropped. `ILike` / `NotILike` are never produced.
+//!   (d) CASE: `operand` is always `None` (legacy is searched-CASE only);
+//!       the source `branches` field maps to the destination `conditions`.
+//!   (e) `CommonInsertSource::DefaultValues` -> `InsertSource::Values(vec![])`
+//!       (empty `Values`, documented as lossy).
+//!
+//! ## Span loss
+//!
+//! Span is silently dropped for every node crossing the bridge (the
+//! destination `Expression` / `Statement` carry a `Span` field, but the
+//! legacy source carries `tsql_token::Span`; the bridge fills the
+//! destination span with a default). No test here asserts byte offsets.
+//!
+//! ## Exhaustiveness guards
+//!
+//! The legacy enums are NOT `#[non_exhaustive]`, so a `match` in the green
+//! phase compiles to enforce lockstep: adding a new legacy variant breaks the
+//! match. The exhaustiveness tests at the end of this file assert the known
+//! variant counts (5 statement variants, 3 insert-source variants) so a
+//! future contributor cannot silently drop one.
+
+// Test code: unwrap/panic/expect are idiomatic here.
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+#![allow(clippy::expect_used)]
+
+use common_sql::ast::{
+    InsertSource as SqlInsertSource, LimitClause as SqlLimitClause, OrderByItem as SqlOrderByItem,
+    SelectItem as SqlSelectItem, SelectStatement as SqlSelectStatement,
+    SortDirection as SqlSortDirection, Statement as SqlStatement, TableFactor as SqlTableFactor,
+};
+use tsql_parser::common::{
+    CommonAssignment, CommonDeleteStatement, CommonExpression, CommonIdentifier,
+    CommonInsertSource, CommonInsertStatement, CommonLimitClause, CommonLiteral, CommonOrderByItem,
+    CommonSelectItem, CommonSelectStatement, CommonStatement, CommonTableReference,
+    CommonUpdateStatement,
+};
+// The `convert` entry point will be re-exported from `tsql_parser::common`
+// (approval condition: "Re-export the entry point from mod.rs"). Until the
+// green phase lands it is expected to be missing -> this file does not
+// compile, which is the intended red state.
+use tsql_parser::common::convert;
+// `From` impls live in `convert_common_sql.rs` and are in scope via the
+// `common_sql::ast` types themselves (trait `From` is in the prelude).
+use common_sql::ast::Expression as SqlExpression;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn legacy_span() -> tsql_token::Span {
+    tsql_token::Span::new(1, 2)
+}
+
+fn lit_int(n: i64) -> CommonExpression {
+    CommonExpression::Literal(CommonLiteral::Integer(n))
+}
+
+fn ident(name: &str) -> CommonExpression {
+    CommonExpression::Identifier(CommonIdentifier {
+        name: name.to_string(),
+    })
+}
+
+fn trivial_select() -> CommonSelectStatement {
+    CommonSelectStatement {
+        span: legacy_span(),
+        distinct: false,
+        columns: vec![CommonSelectItem::Wildcard],
+        from: vec![],
+        where_clause: None,
+        group_by: vec![],
+        having: None,
+        order_by: vec![],
+        limit: None,
+    }
+}
+
+// =====================================================================
+// CommonSelectItem / CommonOrderByItem / CommonLimitClause
+// =====================================================================
+
+#[test]
+fn select_item_expression_with_alias_maps() {
+    let src = CommonSelectItem::Expression(ident("c"), Some("alias".to_string()));
+    let got = SqlSelectItem::from(src);
+    match got {
+        SqlSelectItem::Expression { alias, .. } => {
+            assert_eq!(alias.unwrap().value(), "alias");
+        }
+        other => panic!("expected Expression, got {other:?}"),
+    }
+}
+
+#[test]
+fn select_item_expression_without_alias_maps() {
+    let src = CommonSelectItem::Expression(ident("c"), None);
+    let got = SqlSelectItem::from(src);
+    match got {
+        SqlSelectItem::Expression { alias, .. } => assert!(alias.is_none()),
+        other => panic!("expected Expression, got {other:?}"),
+    }
+}
+
+#[test]
+fn select_item_wildcard_maps() {
+    let got = SqlSelectItem::from(CommonSelectItem::Wildcard);
+    assert!(matches!(got, SqlSelectItem::Wildcard));
+}
+
+#[test]
+fn select_item_qualified_wildcard_maps() {
+    let got = SqlSelectItem::from(CommonSelectItem::QualifiedWildcard("t".to_string()));
+    match got {
+        SqlSelectItem::QualifiedWildcard { table } => assert_eq!(table.value(), "t"),
+        other => panic!("expected QualifiedWildcard, got {other:?}"),
+    }
+}
+
+#[test]
+fn order_by_item_asc_maps_to_direction_asc() {
+    let src = CommonOrderByItem {
+        expr: ident("name"),
+        asc: true,
+    };
+    let got = SqlOrderByItem::from(src);
+    assert_eq!(got.direction, Some(SqlSortDirection::Asc));
+}
+
+#[test]
+fn order_by_item_desc_maps_to_direction_desc() {
+    let src = CommonOrderByItem {
+        expr: ident("name"),
+        asc: false,
+    };
+    let got = SqlOrderByItem::from(src);
+    assert_eq!(got.direction, Some(SqlSortDirection::Desc));
+}
+
+#[test]
+fn limit_clause_maps_limit_and_offset() {
+    let src = CommonLimitClause {
+        limit: lit_int(10),
+        offset: Some(lit_int(2)),
+    };
+    let got = SqlLimitClause::from(src);
+    assert!(matches!(got.limit, SqlExpression::Literal(_)));
+    assert!(got.offset.is_some());
+}
+
+#[test]
+fn limit_clause_without_offset_maps() {
+    let src = CommonLimitClause {
+        limit: lit_int(10),
+        offset: None,
+    };
+    let got = SqlLimitClause::from(src);
+    assert!(got.offset.is_none());
+}
+
+// =====================================================================
+// CommonTableReference / CommonAssignment
+// =====================================================================
+
+#[test]
+fn table_reference_table_maps_to_table_factor() {
+    let src = CommonTableReference::Table {
+        name: "users".to_string(),
+        alias: Some("u".to_string()),
+        span: legacy_span(),
+    };
+    let got = SqlTableFactor::from(src);
+    match got {
+        SqlTableFactor::Table { name, alias } => {
+            assert_eq!(name.name(), "users");
+            assert_eq!(alias.unwrap().name(), "u");
+        }
+        other => panic!("expected Table, got {other:?}"),
+    }
+}
+
+#[test]
+fn table_reference_table_without_alias_maps() {
+    let src = CommonTableReference::Table {
+        name: "users".to_string(),
+        alias: None,
+        span: legacy_span(),
+    };
+    let got = SqlTableFactor::from(src);
+    match got {
+        SqlTableFactor::Table { alias, .. } => assert!(alias.is_none()),
+        other => panic!("expected Table, got {other:?}"),
+    }
+}
+
+#[test]
+fn table_reference_derived_maps_to_derived_factor() {
+    let src = CommonTableReference::Derived {
+        subquery: Box::new(trivial_select()),
+        alias: Some("sub".to_string()),
+        span: legacy_span(),
+    };
+    let got = SqlTableFactor::from(src);
+    match got {
+        SqlTableFactor::Derived { alias, .. } => {
+            assert_eq!(alias.unwrap().name(), "sub");
+        }
+        other => panic!("expected Derived, got {other:?}"),
+    }
+}
+
+#[test]
+fn assignment_maps_column_and_value() {
+    let src = CommonAssignment {
+        column: "status".to_string(),
+        value: lit_int(1),
+    };
+    let got = common_sql::ast::Assignment::from(src);
+    assert_eq!(got.column.value(), "status");
+    assert!(matches!(got.value, SqlExpression::Literal(_)));
+}
+
+// =====================================================================
+// CommonSelectStatement (full mapping, not just the projection-only stub)
+// =====================================================================
+
+#[test]
+fn select_statement_maps_projection_and_first_from() {
+    // Design decision (b): Vec<CommonTableReference> -> Option<TableFactor>
+    // takes the first element; extras are dropped (documented lossy).
+    let src = CommonSelectStatement {
+        span: legacy_span(),
+        distinct: true,
+        columns: vec![CommonSelectItem::Wildcard],
+        from: vec![CommonTableReference::Table {
+            name: "users".to_string(),
+            alias: None,
+            span: legacy_span(),
+        }],
+        where_clause: None,
+        group_by: vec![],
+        having: None,
+        order_by: vec![],
+        limit: None,
+    };
+    let got = SqlSelectStatement::from(src);
+    assert_eq!(got.projection.len(), 1);
+    assert!(got.from.is_some());
+}
+
+#[test]
+fn select_statement_empty_from_yields_none() {
+    let got = SqlSelectStatement::from(trivial_select());
+    assert!(got.from.is_none());
+}
+
+#[test]
+fn select_statement_carries_where_group_having_order_limit() {
+    let src = CommonSelectStatement {
+        span: legacy_span(),
+        distinct: false,
+        columns: vec![CommonSelectItem::Wildcard],
+        from: vec![],
+        where_clause: Some(ident("active")),
+        group_by: vec![ident("dept")],
+        having: Some(ident("total")),
+        order_by: vec![CommonOrderByItem {
+            expr: ident("name"),
+            asc: true,
+        }],
+        limit: Some(CommonLimitClause {
+            limit: lit_int(10),
+            offset: None,
+        }),
+    };
+    let got = SqlSelectStatement::from(src);
+    assert!(got.where_clause.is_some());
+    assert!(got.group_by.is_some());
+    assert!(got.having.is_some());
+    assert!(got.order_by.is_some());
+    assert!(got.limit.is_some());
+}
+
+// =====================================================================
+// convert() entry point + CommonStatement dispatch
+// =====================================================================
+
+#[test]
+fn convert_select_statement_returns_some_select() {
+    let got = convert(CommonStatement::Select(trivial_select()));
+    assert!(got.is_some());
+    assert!(matches!(got.unwrap(), SqlStatement::Select(_)));
+}
+
+#[test]
+fn convert_insert_values_returns_some_insert() {
+    let inner = CommonInsertStatement {
+        span: legacy_span(),
+        table: "users".to_string(),
+        columns: vec!["id".to_string()],
+        source: CommonInsertSource::Values(vec![vec![lit_int(1)]]),
+    };
+    let got = convert(CommonStatement::Insert(inner));
+    assert!(got.is_some());
+    assert!(matches!(got.unwrap(), SqlStatement::Insert(_)));
+}
+
+#[test]
+fn convert_insert_default_values_maps_to_empty_values_rows() {
+    // Design decision (e): DefaultValues -> InsertSource::Values(vec![]).
+    let inner = CommonInsertStatement {
+        span: legacy_span(),
+        table: "t".to_string(),
+        columns: vec![],
+        source: CommonInsertSource::DefaultValues,
+    };
+    let got = convert(CommonStatement::Insert(inner)).expect("Some");
+    match got {
+        SqlStatement::Insert(ins) => match ins.source {
+            SqlInsertSource::Values(rows) => assert!(rows.is_empty()),
+            other => panic!("expected Values, got {other:?}"),
+        },
+        other => panic!("expected Insert, got {other:?}"),
+    }
+}
+
+#[test]
+fn convert_insert_select_returns_some_insert() {
+    let inner = CommonInsertStatement {
+        span: legacy_span(),
+        table: "archive".to_string(),
+        columns: vec!["id".to_string()],
+        source: CommonInsertSource::Select(Box::new(trivial_select())),
+    };
+    let got = convert(CommonStatement::Insert(inner));
+    assert!(got.is_some());
+}
+
+#[test]
+fn convert_update_returns_some_update() {
+    let inner = CommonUpdateStatement {
+        span: legacy_span(),
+        table: "users".to_string(),
+        assignments: vec![CommonAssignment {
+            column: "name".to_string(),
+            value: lit_int(1),
+        }],
+        where_clause: None,
+    };
+    let got = convert(CommonStatement::Update(inner));
+    assert!(got.is_some());
+    assert!(matches!(got.unwrap(), SqlStatement::Update(_)));
+}
+
+#[test]
+fn convert_delete_returns_some_delete() {
+    let inner = CommonDeleteStatement {
+        span: legacy_span(),
+        table: "users".to_string(),
+        where_clause: None,
+    };
+    let got = convert(CommonStatement::Delete(inner));
+    assert!(got.is_some());
+    assert!(matches!(got.unwrap(), SqlStatement::Delete(_)));
+}
+
+#[test]
+fn convert_dialect_specific_returns_none() {
+    // Design decision (a): DialectSpecific has no destination variant, so the
+    // free fn `convert` returns None (NOT a plain From<CommonStatement>).
+    let src = CommonStatement::DialectSpecific {
+        description: "GRANT".to_string(),
+        span: legacy_span(),
+    };
+    let got = convert(src);
+    assert!(got.is_none());
+}
+
+// =====================================================================
+// Exhaustiveness guards
+// =====================================================================
+
+#[test]
+fn insert_source_exhaustiveness_all_three_variants_map() {
+    let cases = [
+        CommonInsertSource::Values(vec![]),
+        CommonInsertSource::Select(Box::new(trivial_select())),
+        CommonInsertSource::DefaultValues,
+    ];
+    for c in cases {
+        let stmt = CommonInsertStatement {
+            span: legacy_span(),
+            table: "t".to_string(),
+            columns: vec![],
+            source: c,
+        };
+        assert!(convert(CommonStatement::Insert(stmt)).is_some());
+    }
+}
+
+#[test]
+fn statement_exhaustiveness_all_five_variants_handled() {
+    // DialectSpecific -> None; the other four -> Some(...).
+    let cases: Vec<CommonStatement> = vec![
+        CommonStatement::Select(trivial_select()),
+        CommonStatement::Insert(CommonInsertStatement {
+            span: legacy_span(),
+            table: "t".to_string(),
+            columns: vec![],
+            source: CommonInsertSource::DefaultValues,
+        }),
+        CommonStatement::Update(CommonUpdateStatement {
+            span: legacy_span(),
+            table: "t".to_string(),
+            assignments: vec![],
+            where_clause: None,
+        }),
+        CommonStatement::Delete(CommonDeleteStatement {
+            span: legacy_span(),
+            table: "t".to_string(),
+            where_clause: None,
+        }),
+        CommonStatement::DialectSpecific {
+            description: "x".to_string(),
+            span: legacy_span(),
+        },
+    ];
+    let mut some = 0;
+    let mut none = 0;
+    for c in cases {
+        if convert(c).is_some() {
+            some += 1;
+        } else {
+            none += 1;
+        }
+    }
+    assert_eq!(some, 4);
+    assert_eq!(none, 1);
+}


### PR DESCRIPTION
## 概要

`common-sql` 方言非依存 AST クレートの抽出と、`tsql-parser` 内レガシー `Common*` AST → 独立 `common_sql::ast` クレートへの**変換ブリッジ**を完了させます。これは #147（mysql-emitter トランスパイル実装）の T0 前提であり、P1 結合負債（mysql-emitter が tsql-parser 全体に直接依存）を解消して common-sql のみへの依存へ再配線するための基盤です。

## 主な変更

### common-sql クレート（#144）
- 方言非依存の共通 SQL AST（Statement / Expression / DataType / Visitor pattern 他）
- SELECT / JOIN / DDL 系 AST ノード、Visitor trait

### tsql-parser 変換ブリッジ（#148）
- **leaf 変換**: `CommonDataType` / `CommonLiteral` / `CommonIdentifier` / `CommonUnaryOperator`
- **composite 変換** (`convert_common_sql.rs`):
  - `convert(stmt: CommonStatement) -> Option<Statement>` エントリポイント（`mod.rs` で再エクスポート）
  - `From<CommonSelectStatement>`（projection/FROM/WHERE/GROUP BY/HAVING/ORDER BY/LIMIT）
  - `From<CommonTableReference>` / `From<CommonInsertStatement>` / `From<CommonUpdateStatement>` / `From<CommonDeleteStatement>` / `From<CommonAssignment>`
  - `From<CommonSelectItem>` / `From<CommonOrderByItem>` / `From<CommonLimitClause>` をスタンドアロン化し `From<CommonSelectStatement>` を委譅（DRY）
- **コンパイルブロック解消**: 余分な `}`（パースエラーで13個の潜在エラーを隠蔽）、欠落 import（`CommonStatement`/`CommonTableReference` 他）、GROUP BY の `From<CommonExpression>` 適用漏れ
- **統合テスト** `convert_common_sql_bridge.rs`（24テスト）: 5ステートメント variant の dispatch、全節マッピング、網羅性ガード（5 stmt + 3 insert-source）

## 検証

- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets -p tsql-parser -- -D warnings` ✓
- `cargo nextest run -p tsql-parser` → **476 passed, 2 skipped**

## ⚠️ マージブロッカーについて（透明性）

本ブランチには **mysql-emitter の WIP スキャフォールド**（`f951427` / `4e3dc98`、gate-incomplete として意図的にコミット）が含まれます。これらは #147 の進行中作業で未配線のため、CI の `cargo clippy --workspace --all-targets -- -D warnings`（Lint job）が失敗します。tsql-parser ブリッジ本体は完全に green ですが、**ワークスペース全体としては mysql-emitter WIP がマージをブロック**しています。

マージ可能にする選択肢:
1. mysql-emitter WIP 2コミットを除外（rebase）→ クリーンな green PR にしてマージ
2. #147 を先行して mysql-emitter を clippy-clean にする
3. 本 PR を draft として #147 進捗まで保留

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: glm 4.7 <noreply@zhipuai.cn>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared SQL AST with support for identifiers, spans, literals, expressions, data types, joins, clauses, DDL, DML, and select statements.
  * Added a visitor interface for traversing SQL trees.
  * Added MySQL conversion and syntax helpers for data types and selected SQL constructs.
  * Expanded workspace support with a new common SQL crate.

* **Bug Fixes**
  * Improved case-insensitive matching in code actions, hover resolution, and reference lookup behavior.

* **Tests**
  * Added broad test coverage for AST types, visitor behavior, conversions, and search helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->